### PR TITLE
feat: 백엔드 Controller는 SecurityContext로부터 사용자 인증 정보를 사용할 수 있다.

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/engdu/presentation/EngduController.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/presentation/EngduController.java
@@ -11,7 +11,6 @@ import com.gyu.engdu.domain.engdu.presentation.dto.request.SubmissionEngduReques
 import com.gyu.engdu.domain.engdu.presentation.dto.response.EngduDetailResponse;
 import com.gyu.engdu.domain.engdu.presentation.dto.response.EngduSummaryResponse;
 import com.gyu.engdu.domain.engdu.presentation.dto.response.SubmissionEngduResponse;
-import com.gyu.engdu.security.JwtUserDetails;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -40,9 +39,8 @@ public class EngduController {
   @PostMapping
   public ResponseEntity<Void> createEngdu(
       @RequestBody CreateEngduRequest request,
-      @AuthenticationPrincipal JwtUserDetails userDetails
+      @AuthenticationPrincipal(expression = "userId") Long userId
   ) {
-    Long userId = userDetails.getUserId();
     String topic = request.topic();
     String level = request.level();
     Long engduId = createEngduService.create(userId, topic, level);
@@ -54,9 +52,8 @@ public class EngduController {
   @DeleteMapping("/{engduId}")
   public ResponseEntity<Void> deleteEngdu(
       @PathVariable("engduId") Long engduId,
-      @AuthenticationPrincipal JwtUserDetails userDetails
+      @AuthenticationPrincipal(expression = "userId") Long userId
   ) {
-    Long userId = userDetails.getUserId();
     deleteEngduService.delete(userId, engduId);
     return ResponseEntity.noContent().build();
   }
@@ -68,9 +65,8 @@ public class EngduController {
       @RequestParam(name = "sortKey", defaultValue = "CREATED_AT") EngduSortKey sortKey,
       @RequestParam(name = "direction", defaultValue = "DESC") Sort.Direction direction,
       @RequestParam(name = "isSolved", defaultValue = "ALL") SolvedFilter solvedFilter,
-      @AuthenticationPrincipal JwtUserDetails userDetails
+      @AuthenticationPrincipal(expression = "userId") Long userId
   ) {
-    Long userId = userDetails.getUserId();
     Page<EngduSummaryResponse> responses = engduQueryService.searchEngdu(userId, pageNum, size,
         sortKey, direction, solvedFilter);
     return ResponseEntity.ok(responses);
@@ -79,9 +75,8 @@ public class EngduController {
   @GetMapping("/{engduId}")
   public ResponseEntity<EngduDetailResponse> readDetailEngdu(
       @PathVariable("engduId") Long engduId,
-      @AuthenticationPrincipal JwtUserDetails userDetails
+      @AuthenticationPrincipal(expression = "userId") Long userId
   ) {
-    Long userId = userDetails.getUserId();
     return ResponseEntity.ok(engduQueryService.findDetailEngdu(userId, engduId));
   }
 
@@ -90,9 +85,8 @@ public class EngduController {
       @PathVariable("engduId") Long engduId,
       @PathVariable("questionId") Long questionId,
       @RequestBody SubmissionEngduRequest req,
-      @AuthenticationPrincipal JwtUserDetails userDetails
+      @AuthenticationPrincipal(expression = "userId") Long userId
   ) {
-    Long userId = userDetails.getUserId();
     boolean isAnswered = solveQuestionService.solve(userId, engduId, questionId, req.userAnswer());
     return ResponseEntity.ok(new SubmissionEngduResponse(isAnswered));
   }


### PR DESCRIPTION
## 연관된 이슈

closed #20 

## 작업 내용

- JwtAuthenticationFilter에서 인증한 사용자 정보를 @AuthenticationPrincipal 을 적용해 Controller에서 사용할 수 있도록 만들었습니다. 
- 기존에 컨트롤러에서 사용한 userId 하드코딩을 제거했습니다. 
- SpEL([Spring Expression Langauge)을 사용하여 코드 중복을 제거했습니다. (리뷰반영)

### 참고 문서
[Spring Security @AuthenticationPrincipal 문서](https://docs.spring.io/spring-security/reference/servlet/integrations/mvc.html#mvc-authentication-principal)