### PR TITLE
refactor: 구글 OAuth 로그인 uri 하드코딩 제거

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/gyu/engdu/domain/auth/presentation/AuthController.java
@@ -7,6 +7,7 @@ import com.gyu.engdu.domain.auth.presentation.dto.response.AuthTokenResponse;
 import java.net.URI;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -26,14 +27,14 @@ public class AuthController {
   private final GoogleOAuthService googleOAuthService;
   private final ReissueTokenService reissueTokenService;
 
+  @Value("${oauth.google.login-uri}")
+  private String loginUri;
+
   @GetMapping("/url")
   public ResponseEntity<Void> redirectGoogleLoginUrl() {
-    //String redirectUrl = "https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=https://www.ddeng-gu.shop/api/v1/login/oauth/signup&client_id=184642286173-vkd43ig36jr6ui7e4a5r01mtb81ehdo1.apps.googleusercontent.com";
-    String redirectUrl = "https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=http://localhost:8080/api/v1/auth/signup/oauth&client_id=184642286173-vkd43ig36jr6ui7e4a5r01mtb81ehdo1.apps.googleusercontent.com";
-
     return ResponseEntity
         .status(HttpStatus.TEMPORARY_REDIRECT)
-        .location(URI.create(redirectUrl))
+        .location(URI.create(loginUri))
         .build();
   }
 


### PR DESCRIPTION
## 연관된 이슈

closed #36 

## 작업 내용

### 개요
AuthController에서 구글 로그인 리다이렉트 URL을 하드코딩하여 사용하던 방식을 개선하였습니다. 해당 URL을 설정 파일에서 관리할 수 있도록 @Value 어노테이션을 통해 값을 주입받도록 변경하여, 유연성과 유지보수성을 높였습니다.


### 변경 내용
AuthController 리팩토링
- 하드코딩 제거: 기존의 긴 URL 문자열을 제거했습니다.
- 프로퍼티 주입: @Value("${oauth.google.login-uri}")를 사용하여 loginUri 필드에 값을 주입받도록 수정했습니다.
- 리다이렉트 로직 수정: redirectGoogleLoginUrl 메서드에서 주입받은 loginUri를 사용해 리다이렉트하도록 변경했습니다.

