### PR TITLE
fix: 서비스 도메인에 대해 CORS 허용

### DIFF
--- a/src/main/java/com/gyu/engdu/security/SecurityConfig.java
+++ b/src/main/java/com/gyu/engdu/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.addAllowedOrigin("http://localhost:5173");
+    configuration.addAllowedOrigin("https://engdu.shop");
     configuration.addAllowedMethod("*");
     configuration.addAllowedHeader("*");
     configuration.setAllowCredentials(true);


### PR DESCRIPTION
## 연관된 이슈
closed #42 

## 작업 내용
기존의 시큐리티 설정에선 프론트의 로컬 환경(localhost:5173)에서만 CORS를 허락하고 있었습니다.
배포된 프론트 서버에서 정상적으로 API를 수행할 수 있도록 배포 도메인에 대해 CORS 허락하는 코드를 추가했습니다.