### PR TITLE
[REFACTOR] 잉듀 상세 조회 api 응답 구조 변경

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/engdu/application/dto/response/EngduDetailResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/application/dto/response/EngduDetailResponse.java
@@ -14,17 +14,25 @@ import java.util.List;
 public record EngduDetailResponse(
         Long engduId,
         Meta meta,
-        List<Part> parts) {
+        Parts parts) {
 
     public static EngduDetailResponse fromEntity(Engdu engdu) {
-        List<Part> parts = engdu.getParts().stream()
+        Part initial = engdu.getParts().stream()
+                .filter(p -> p.getPartType() == PartType.INITIAL && p.getStatus() == PartStatus.DONE)
+                .findFirst()
                 .map(Part::fromEntity)
-                .toList();
+                .orElse(null);
+
+        Part complete = engdu.getParts().stream()
+                .filter(p -> p.getPartType() == PartType.COMPLETE && p.getStatus() == PartStatus.DONE)
+                .findFirst()
+                .map(Part::fromEntity)
+                .orElse(null);
 
         return new EngduDetailResponse(
                 engdu.getId(),
                 new Meta(engdu.getTitle(), engdu.getTopic(), engdu.getLikeStatus()),
-                parts);
+                new Parts(initial, complete));
     }
 
     public record Meta(
@@ -33,25 +41,17 @@ public record EngduDetailResponse(
             LikeStatus likeStatus) {
     }
 
+    public record Parts(
+            Part INITIAL,
+            Part COMPLETE) {
+    }
+
     public record Part(
-            PartType partType,
-            PartStatus status,
             ArticleResponse article,
             List<QuestionResponse> questions) {
 
-        /**
-         * Part 엔티티를 DTO로 변환합니다.
-         * DONE 상태인 경우에만 article/questions를 채우고, 그 외(PENDING/CREATING/FAILED)는 null을
-         * 반환합니다.
-         * 클라이언트는 status 값으로 폴링 여부를 판단합니다.
-         */
         public static Part fromEntity(com.gyu.engdu.domain.engdu.domain.Part part) {
-            if (part.getStatus() != PartStatus.DONE) {
-                return new Part(part.getPartType(), part.getStatus(), null, null);
-            }
             return new Part(
-                    part.getPartType(),
-                    part.getStatus(),
                     ArticleResponse.of(part.getArticle()),
                     part.getQuestions().stream()
                             .map(QuestionResponse::fromEntity)

--- a/src/test/java/com/gyu/engdu/domain/engdu/application/EngduQueryServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/engdu/application/EngduQueryServiceTest.java
@@ -141,14 +141,14 @@ class EngduQueryServiceTest extends IntegrationTestSupport {
 
     // then
     assertThat(response.engduId()).isEqualTo(engdu.getId());
-    assertThat(response.parts()).hasSize(1);
-    assertThat(response.parts().get(0).questions()).hasSize(2)
+    assertThat(response.parts().INITIAL()).isNotNull();
+    assertThat(response.parts().INITIAL().questions()).hasSize(2)
         .extracting("questionId", "answer", "content")
         .containsExactlyInAnyOrder(
             tuple(question1.getId(), (byte) 1, "Question Content1"),
             tuple(question2.getId(), null, "Question Content2"));
 
-    assertThat(response.parts().get(0).article().chunks()).hasSize(2)
+    assertThat(response.parts().INITIAL().article().chunks()).hasSize(2)
         .extracting("en", "kor")
         .containsExactly(
             tuple("Chunk1", "한국어청크1"),


### PR DESCRIPTION
## 연관된 이슈

 - closed #86 

## 작업 내용

### 개요

 Engdu 상세 조회 API의 응답 구조를 클라이언트에서 더 사용하기 편하도록 리팩토링했습니다. 기존의 리스트 형태였던 파트 정보를 `INITIAL`과 `COMPLETE`로 명확히 구분된 객체 구조로 변경했습니다.

### 변경 사항

 - **응답 데이터 구조 변경**: `parts` 필드를 `List`에서 `INITIAL`, `COMPLETE`를 가진 객체로 변경했습니다.
 - **DTO 필터링 로직 추가**: `EngduDetailResponse.fromEntity` 메서드에서 각 파트 타입과 상태(`DONE`)를 기준으로 데이터를 매핑하도록 수정했습니다.
 - **클라이언트 편의성 개선**: 클라이언트에서 파트 타입을 구분하기 위해 리스트를 순회하거나 인덱스에 의존할 필요 없이, 즉시 필요한 파트 정보를 가져올 수 있게 되었습니다.
