### PR TITLE
[FIX] 잉듀 특정 파트 생성 시 제목이 저장되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/engdu/application/CreateEngduService.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/application/CreateEngduService.java
@@ -34,6 +34,6 @@ public class CreateEngduService {
     GeneratedEngduResponse response = engduClient.generateEngdu(request);
 
     // [TX 3]: 파트 디비 영속 및 상태 변경(DONE)을 커밋
-    partCommandService.saveResultAndMarkDone(partId, step, response);
+    partCommandService.saveResultAndMarkDone(partId, response);
   }
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/application/PartCommandService.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/application/PartCommandService.java
@@ -53,12 +53,12 @@ public class PartCommandService {
     }
 
     @Transactional
-    public void saveResultAndMarkDone(Long partId, PartType partType, GeneratedEngduResponse response) {
+    public void saveResultAndMarkDone(Long partId, GeneratedEngduResponse response) {
         Part part = partRepository.findById(partId)
                 .orElseThrow(() -> new PartNotFoundException(partId));
 
         // INITIAL 파트 저장 시 LLM이 생성한 타이틀을 Engdu에 반영합니다.
-        if (partType == PartType.INITIAL) {
+        if (part.getPartType() == PartType.INITIAL) {
             part.getEngdu().changeTitle(response.title());
         }
 


### PR DESCRIPTION
## 연관된 이슈

- closed #91

## 작업 내용

### 개요

 INITIAL 파트 생성 및 저장 시 LLM이 생성한 타이틀을 엔티티에 반영하지 않던 버그를 수정했습니다.

### 변경 사항

 - **데이터 저장 로직 보완**: 결과 저장 메서드에 파트 타입을 판별하는 파라미터를 추가하고, 파트 타입이 `INITIAL`일 경우 LLM 응답에 포함된 작업을 엔티티 타이틀로 업데이트하도록 로직을 복구했습니다.
 - **스프링부트 컨테이너 네트워크 변경**: 컴포즈 파일에서 MySQL 컨테이너를 제외함에 따른 네트워크를 external을 사용하도록 변경했습니다.