### PR TITLE
[FIX] 프론트엔드 로컬 환경에서 CORS 설정 변경

### DIFF
--- a/src/main/java/com/gyu/engdu/security/SecurityConfig.java
+++ b/src/main/java/com/gyu/engdu/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.addAllowedOrigin("http://localhost:5173");
+    configuration.addAllowedOrigin("https://localhost:5173");
     configuration.addAllowedOrigin("https://engdu.shop");
     configuration.addAllowedOrigin("https://engdu.co.kr");
     configuration.addAllowedMethod("*");


### PR DESCRIPTION
## 작업 내용

### 개요

로컬 프론트엔드 환경에서 CROS 에러를 방지하기 위해 `SecurtiyCoinfg`에서 https에 대한 CORS 설정을 변경했습니다.