### PR TITLE
[HOTFIX] 프로매테우스 액츄에이터 API 로깅에서 제외

### DIFF
--- a/src/main/java/com/gyu/engdu/config/RequestLoggingFilter.java
+++ b/src/main/java/com/gyu/engdu/config/RequestLoggingFilter.java
@@ -23,11 +23,14 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } finally {
             long elapsed = System.currentTimeMillis() - start;
-            log.info("[{}] {} {} → {}ms",
-                    response.getStatus(),
-                    request.getMethod(),
-                    request.getRequestURI(),
-                    elapsed);
+            String uri = request.getRequestURI();
+            if (!"/actuator/prometheus".equals(uri)) {
+                log.info("[{}] {} {} → {}ms",
+                        response.getStatus(),
+                        request.getMethod(),
+                        uri,
+                        elapsed);
+            }
         }
     }
 }


### PR DESCRIPTION
## 연관된 이슈

 - closed #100 

## 작업 내용

### 개요

프로매테우스 액츄에이터 API의 무분별한 로깅으로 정상적인 애플리케이션 로그를 한눈에 알아보기 힘든 문제가 발생했습니다.
이를 해결하기 위해 RequestLogginFilter 에서 액츄에이터 관련 로깅을 제거합니다.
