### PR TITLE
[FEAT] SQS 메시지 발행, 소비 메트릭을 등록하여 그라파나에서 모니터링 할 수 있다.

### DIFF
--- a/src/main/java/com/gyu/engdu/config/MetricsAopConfig.java
+++ b/src/main/java/com/gyu/engdu/config/MetricsAopConfig.java
@@ -1,0 +1,15 @@
+package com.gyu.engdu.config;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsAopConfig {
+
+  @Bean
+  public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+    return new TimedAspect(meterRegistry);
+  }
+}

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessageListener.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessageListener.java
@@ -5,6 +5,7 @@ import com.gyu.engdu.domain.engdu.application.PartCommandService;
 import com.gyu.engdu.domain.engdu.domain.Part;
 import com.gyu.engdu.domain.engdu.infra.dto.EngduSqsMessage;
 import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.micrometer.core.annotation.Timed;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ public class EngduSqsMessageListener {
     private final CreateEngduService createEngduService;
     private final PartCommandService partCommandService;
 
+    @Timed("sqs")
     @SqsListener("${spring.cloud.aws.sqs.queue-name}")
     public void listen(EngduSqsMessage message) {
         log.info("SQS 메시지 수신 engduId={}, userId={}, step={}",

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessagePublisher.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessagePublisher.java
@@ -3,6 +3,7 @@ package com.gyu.engdu.domain.engdu.infra;
 import com.gyu.engdu.domain.engdu.application.EngduMessagePublisher;
 import com.gyu.engdu.domain.engdu.infra.dto.EngduSqsMessage;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +19,7 @@ public class EngduSqsMessagePublisher implements EngduMessagePublisher {
     @Value("${spring.cloud.aws.sqs.queue-name}")
     private String queueName;
 
+    @Timed("sqs")
     public void publish(EngduSqsMessage message) {
         log.info("SQS 메시지 발행 engduId={}, userId={}, step={}",
                 message.engduId(), message.userId(), message.step());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 server:
   port: 8080
+  tomcat:
+    mbeanregistry:
+      enabled: true
 
 spring:
   application:
@@ -51,7 +54,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus, health, info
+        include: "*"
   metrics:
     distribution:
       percentiles-histogram:


### PR DESCRIPTION
## 연관된 이슈

- closed #103

## 작업 내용
### 개요
SQS 메시지 발행/소비 로직에 Micrometer 메트릭을 등록하고, 톰캣 스레드 풀 메트릭을 포함한 전체 actuator 엔드포인트를 노출하도록 설정을 변경했습니다.

### 변경 사항
- **MetricsAopConfig 추가**: `@Timed` 어노테이션이 AOP로 동작하려면 `TimedAspect` 빈이 필요하므로 이를 등록하는 설정 클래스를 추가했습니다.
- **SQS 메트릭 등록**: `EngduSqsMessagePublisher`와 `EngduSqsMessageListener`의 핵심 메서드에 `@Timed("sqs")` 어노테이션을 추가하여 발행/소비 소요 시간을 Prometheus에서 수집할 수 있도록 했습니다.
- **톰캣 스레드 풀 메트릭 활성화**: `application.yml`에 `server.tomcat.mbeanregistry.enabled: true` 설정을 추가했습니다.
- **전체 actuator 엔드포인트 노출**: `management.endpoints.web.exposure.include`를 `"*"`로 변경하여 모든 메트릭을 노출하도록 했습니다.
