### PR TITLE
[FEAT] 슬로우 쿼리 임계값 설정 및 로그백 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,10 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         jdbc:
           batch_size: 100
+        session:
+          events:
+            log:
+              LOG_QUERIES_SLOWER_THAN_MS: 500  # 500ms 이상 쿼리를 슬로우 쿼리로 판정
 
   cloud:
     aws:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -17,6 +17,11 @@
       </encoder>
     </appender>
 
+    <!-- 슬로우 쿼리 전용 로거 -->
+    <logger name="org.hibernate.SQL_SLOW" level="INFO" additivity="false">
+      <appender-ref ref="CONSOLE"/>
+    </logger>
+
     <root level="DEBUG">
       <appender-ref ref="CONSOLE"/>
     </root>
@@ -38,6 +43,11 @@
         <totalSizeCap>${LOG_TOTAL_SIZE_CAP}</totalSizeCap>
       </rollingPolicy>
     </appender>
+
+    <!-- 슬로우 쿼리 전용 로거 -->
+    <logger name="org.hibernate.SQL_SLOW" level="INFO" additivity="false">
+      <appender-ref ref="FILE"/>
+    </logger>
 
     <root level="INFO">
       <appender-ref ref="FILE"/>


### PR DESCRIPTION
## 연관된 이슈

- closed #105

## 작업 내용

### 개요

 Hibernate의 슬로우 쿼리 로깅 기능을 활성화하여 성능 저하를 유발하는 쿼리를 모니터링할 수 있도록 설정했습니다.

### 변경 사항

 - `application.yml`: 슬로우 쿼리 판정 기준을 500ms로 설정 (`LOG_QUERIES_SLOWER_THAN_MS: 500`)
 - `logback-spring.xml`: `org.hibernate.SQL_SLOW` 로거 설정을 추가하여 지정된 시간보다 오래 걸리는 쿼리가 발생할 경우 INFO 레벨로 로그를 남기도록 수정

### 주요 고민 및 해결 과정

 - 문제점: 시스템 운영 중 특정 기능에서의 응답 지연 발생 시, 어떤 SQL 쿼리가 원인인지 파악하기 어려움
 - 해결 과정: Hibernate에서 제공하는 슬로우 쿼리 로깅 설정을 도입하여 성능 이슈가 있는 쿼리를 자동으로 감지하고 기록하도록 개선함
