### PR TITLE
[FEAT] lighthouse ci 사용을 위한 fake login api 구현 

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/auth/application/FakeLoginService.java
+++ b/src/main/java/com/gyu/engdu/domain/auth/application/FakeLoginService.java
@@ -1,0 +1,27 @@
+package com.gyu.engdu.domain.auth.application;
+
+import com.gyu.engdu.domain.auth.application.dto.response.AuthTokenServiceResponse;
+import com.gyu.engdu.domain.user.application.UserQueryService;
+import com.gyu.engdu.domain.user.domain.User;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FakeLoginService {
+
+    private final CreateTokenService createTokenService;
+    private final PersistTokenService persistTokenService;
+    private final UserQueryService userQueryService;
+
+    public AuthTokenServiceResponse fakeLogin(Long userId) {
+        User user = userQueryService.findExistingUser(userId);
+        AuthTokenServiceResponse authToken = createTokenService.createAuthToken(
+                user.getId(), user.getRole(), new Date());
+        persistTokenService.persistRefreshToken(authToken.refreshToken());
+        return authToken;
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/auth/presentation/StagingAuthController.java
+++ b/src/main/java/com/gyu/engdu/domain/auth/presentation/StagingAuthController.java
@@ -1,21 +1,18 @@
 package com.gyu.engdu.domain.auth.presentation;
 
+import com.gyu.engdu.domain.auth.application.FakeLoginService;
 import com.gyu.engdu.domain.auth.application.GoogleOAuthService;
-import com.gyu.engdu.domain.auth.application.LogoutService;
-import com.gyu.engdu.domain.auth.application.ReissueTokenService;
 import com.gyu.engdu.domain.auth.application.dto.response.AuthTokenServiceResponse;
 import com.gyu.engdu.domain.auth.presentation.dto.response.AuthTokenResponse;
 import java.net.URI;
-import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,61 +20,48 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
-public class AuthController {
+@Profile("!prod")
+public class StagingAuthController {
 
   private static final long REFRESH_TOKEN_MAX_AGE_SECONDS = 14 * 24 * 60 * 60;
+  private static final long FAKE_LOGIN_USER_ID = 1L;
   private final GoogleOAuthService googleOAuthService;
-  private final ReissueTokenService reissueTokenService;
-  private final LogoutService logoutService;
+  private final FakeLoginService fakeLoginService;
 
-  @Value("${oauth.google.login-uri}")
-  private String loginUri;
+  @Value("${oauth.google.local-login-uri}")
+  private String localLoginUri;
 
-  @Value("${oauth.google.redirect-uri}")
-  private String redirectUri;
+  @Value("${oauth.google.local-redirect-uri}")
+  private String localRedirectUri;
 
-  @GetMapping("/url")
-  public ResponseEntity<Void> redirectGoogleLoginUrl() {
+  @GetMapping("/local/url")
+  public ResponseEntity<Void> redirectLocalGoogleLoginUrl() {
     return ResponseEntity
         .status(HttpStatus.TEMPORARY_REDIRECT)
-        .location(URI.create(loginUri))
+        .location(URI.create(localLoginUri))
         .build();
   }
 
-  // google OAuth 회원가입을 위한 메서드. 인증을 시도하고 토큰을 발급함.
-  @GetMapping("/signup/oauth")
-  public ResponseEntity<AuthTokenResponse> loginByGoogle(@RequestParam("code") String code) {
+  @GetMapping("/local/signup/oauth")
+  public ResponseEntity<AuthTokenResponse> loginByGoogleLocal(@RequestParam("code") String code) {
     AuthTokenServiceResponse authTokenServiceResponse = googleOAuthService.signUp(code,
-        redirectUri);
+        localRedirectUri);
     ResponseCookie cookie = createCookie(authTokenServiceResponse.refreshToken().getRawToken(),
         REFRESH_TOKEN_MAX_AGE_SECONDS);
-    AuthTokenResponse authTokenResponse = AuthTokenResponse.from(authTokenServiceResponse);
     return ResponseEntity.ok()
         .header(HttpHeaders.SET_COOKIE, cookie.toString())
-        .body(authTokenResponse);
+        .body(AuthTokenResponse.from(authTokenServiceResponse));
   }
 
-  @GetMapping("/reissue")
-  public ResponseEntity<AuthTokenResponse> reissue(
-      @CookieValue("refresh-token") String refreshToken) {
-    AuthTokenServiceResponse authTokenServiceResponse = reissueTokenService.reissue(refreshToken,
-        new Date());
+  @GetMapping("/fake/signup/oauth")
+  public ResponseEntity<AuthTokenResponse> fakeLogin() {
+    AuthTokenServiceResponse authTokenServiceResponse = fakeLoginService.fakeLogin(
+        FAKE_LOGIN_USER_ID);
     ResponseCookie cookie = createCookie(authTokenServiceResponse.refreshToken().getRawToken(),
         REFRESH_TOKEN_MAX_AGE_SECONDS);
-    AuthTokenResponse authTokenResponse = AuthTokenResponse.from(authTokenServiceResponse);
     return ResponseEntity.ok()
         .header(HttpHeaders.SET_COOKIE, cookie.toString())
-        .body(authTokenResponse);
-  }
-
-  @PostMapping("/logout")
-  public ResponseEntity<Void> logout(
-      @CookieValue("refresh-token") String refreshToken) {
-    logoutService.logout(refreshToken);
-    ResponseCookie deletedCookie = createCookie(refreshToken, 0);
-    return ResponseEntity.noContent()
-        .header(HttpHeaders.SET_COOKIE, deletedCookie.toString())
-        .build();
+        .body(AuthTokenResponse.from(authTokenServiceResponse));
   }
 
   private ResponseCookie createCookie(String rawRefreshToken, long maxAgeSeconds) {

--- a/src/main/java/com/gyu/engdu/security/SecurityConfig.java
+++ b/src/main/java/com/gyu/engdu/security/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/auth/reissue").permitAll()
             .requestMatchers("/api/v1/auth/local/url").permitAll()
             .requestMatchers("/api/v1/auth/local/signup/oauth").permitAll()
+            .requestMatchers("/api/v1/auth/fake/signup/oauth").permitAll()
             .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
             .requestMatchers("/api/v1/**").authenticated()
             .anyRequest().permitAll()


### PR DESCRIPTION
## 연관된 이슈

- closed #109 

## 작업 내용

### 개요

> 프론트엔드 Lighthouse CI 테스트를 위한 스테이징 환경 전용 가짜 로그인(Fake Login) API를 추가했습니다.

### 변경 사항

 - FakeLoginService 신규 생성: `userId=1`인 사용자를 조회하여 액세스 토큰과 리프레시 토큰을 발급하고, 기존 토큰 로테이션 전략에 맞춰 리프레시 토큰을 DB에 영속화하는 로직을 구현했습니다.  
 - StagingAuthController 내 가짜 로그인 API 추가: `GET /api/v1/auth/fake/signup/oauth` 엔드포인트를 구현하여, 호출 시 `userId=1` 사용자의 인증 정보를 생성하고 리프레시 토큰을 쿠키에 담아 반환하도록 설정했습니다.  
- 보안 및 환경 설정: 해당 컨트롤러는 `@Profile("!prod")` 설정을 통해 운영 환경을 제외한 스테이징 및 로컬 환경에서만 활성화되도록 구성하여 보안 위험을 방지했습니다.
