### PR TITLE
[FEAT] MDC 로거를 구현해 요청 전반의 흐름을 추적할 수 있다.

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -107,7 +107,8 @@ CREATE TABLE `message` (
     `published_at` DATETIME(6) NULL,
     `status` VARCHAR(255) NOT NULL,
     `type` VARCHAR(255) NOT NULL,
-    `payload` JSON NOT NULL
+    `payload` JSON NOT NULL,
+    `trace_id` VARCHAR(255) NULL
 ) ENGINE=InnoDB;
 
 -- **************************************** TABLE END****************************************

--- a/src/main/java/com/gyu/engdu/config/MdcLoggingInterceptor.java
+++ b/src/main/java/com/gyu/engdu/config/MdcLoggingInterceptor.java
@@ -1,0 +1,30 @@
+package com.gyu.engdu.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class MdcLoggingInterceptor implements HandlerInterceptor {
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String traceId = UUID.randomUUID()
+                .toString()
+                .substring(0, 8);
+
+        MDC.put(TRACE_ID, traceId);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+            Exception ex) {
+        MDC.clear();
+    }
+}

--- a/src/main/java/com/gyu/engdu/config/WebMvcConfig.java
+++ b/src/main/java/com/gyu/engdu/config/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.gyu.engdu.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final MdcLoggingInterceptor mdcLoggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(mdcLoggingInterceptor);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/engdu/application/EngduMessagePublisher.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/application/EngduMessagePublisher.java
@@ -4,5 +4,5 @@ import com.gyu.engdu.domain.engdu.infra.dto.GenerateEngduPartMessage;
 
 public interface EngduMessagePublisher {
 
-    void publish(GenerateEngduPartMessage message);
+    void publish(GenerateEngduPartMessage message, String traceId);
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessageListener.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessageListener.java
@@ -9,6 +9,8 @@ import io.micrometer.core.annotation.Timed;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,37 +18,45 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EngduSqsMessageListener {
 
-    private final CreateEngduService createEngduService;
-    private final PartCommandService partCommandService;
+  private final CreateEngduService createEngduService;
+  private final PartCommandService partCommandService;
 
-    @Timed("sqs")
-    @SqsListener("${spring.cloud.aws.sqs.queue-name}")
-    public void listen(GenerateEngduPartMessage message) {
-        log.info("SQS 메시지 수신 engduId={}, userId={}, step={}",
-                message.engduId(), message.userId(), message.step());
+  @Timed("sqs")
+  @SqsListener("${spring.cloud.aws.sqs.queue-name}")
+  public void listen(GenerateEngduPartMessage message, @Header(name = "traceId") String traceId) {
+    MDC.put("traceId", traceId);
 
-        // [TX 1] 락 획득 + CREATING 상태 즉시 커밋
-        Optional<Part> partOpt = partCommandService.claimPartCreation(
-                message.engduId(), message.step());
+    try {
+      log.info("[SQS 메시지 수신] 잉듀 파트 생성 시작. engduId={}, userId={}, step={}",
+          message.engduId(), message.userId(), message.step());
 
-        if (partOpt.isEmpty()) {
-            // 이미 파트가 만들어진 상태이거나 다른 워커가 처리 중이므로 정상 ACK 처리한다.
-            log.info("이미 잉듀의 파트가 만들어진 상태이거나 다른 워커가 처리중입니다. engduId={}, step={}",
-                    message.engduId(), message.step());
-            return;
-        }
+      // 락 획득, Part 엔티티 CREATING 상태로 변경
+      Optional<Part> partOpt = partCommandService.claimPartCreation(
+          message.engduId(), message.step());
 
-        Long partId = partOpt.get().getId();
+      // 이미 파트가 만들어진 상태이거나 다른 워커가 처리 중이므로 정상 ACK 처리한다.
+      if (partOpt.isEmpty()) {
+        log.info("[SQS 메시지 수신] 이미 잉듀의 파트가 만들어진 상태이거나 다른 워커가 처리중입니다. engduId={}, step={}",
+            message.engduId(), message.step());
+        return;
+      }
 
-        try {
-            // 예외 발생 시 SQS가 ACK하지 않고 자동 재시도한다. 3번 재시도 실패한다면 DLQ로 작업을 위임한다.
-            createEngduService.generatePart(partId, message.step());
-            log.info("잉듀 파트 생성 완료. engduId={}, step={}", message.engduId(), message.step());
-        } catch (Exception e) {
-            // 즉시 FAILED 기록 및 SQS 재시도를 위해 예외 반환
-            partCommandService.markFailed(partId);
-            log.error("잉듀 파트 생성 실패. engduId={}, step={}", message.engduId(), message.step(), e);
-            throw e;
-        }
+      Long partId = partOpt.get().getId();
+
+      try {
+        // 예외 발생 시 SQS가 ACK하지 않고 자동 재시도한다. 3번 재시도 실패한다면 DLQ로 작업을 위임한다.
+        createEngduService.generatePart(partId, message.step());
+        log.info("[SQS 메시지 수신] 잉듀 파트 생성 완료. engduId={}, step={}", message.engduId(),
+            message.step());
+      } catch (Exception e) {
+        // Part 엔티티 FAILED 상태 변경 및 SQS 재시도를 위해 예외 반환
+        partCommandService.markFailed(partId);
+        log.error("[SQS 메시지 수신] 잉듀 파트 생성 실패. engduId={}, step={}", message.engduId(),
+            message.step(), e);
+        throw e;
+      }
+    } finally {
+      MDC.remove("traceId");
     }
+  }
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessagePublisher.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessagePublisher.java
@@ -6,6 +6,7 @@ import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -14,15 +15,25 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EngduSqsMessagePublisher implements EngduMessagePublisher {
 
-    private final SqsTemplate sqsTemplate;
+  private final SqsTemplate sqsTemplate;
 
-    @Value("${spring.cloud.aws.sqs.queue-name}")
-    private String queueName;
+  @Value("${spring.cloud.aws.sqs.queue-name}")
+  private String queueName;
 
-    @Timed("sqs")
-    public void publish(GenerateEngduPartMessage message) {
-        log.info("SQS 메시지 발행 engduId={}, userId={}, step={}",
-                message.engduId(), message.userId(), message.step());
-        sqsTemplate.send(queueName, message);
+  @Timed("sqs")
+  public void publish(GenerateEngduPartMessage message, String traceId) {
+    MDC.put("traceId", traceId);
+
+    try {
+      sqsTemplate.send(to -> to
+          .queue(queueName)
+          .payload(message)
+          .header("traceId", traceId));
+
+      log.info("[SQS 메시지 발행] 메시지 발행에 성공했습니다. engduId={}, userId={}, step={}",
+          message.engduId(), message.userId(), message.step());
+    } finally {
+      MDC.remove("traceId");
     }
+  }
 }

--- a/src/main/java/com/gyu/engdu/message/application/CreateMessageService.java
+++ b/src/main/java/com/gyu/engdu/message/application/CreateMessageService.java
@@ -7,6 +7,7 @@ import com.gyu.engdu.message.domain.MessageRepository;
 import com.gyu.engdu.message.domain.MessageType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,13 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class CreateMessageService {
 
-    private final MessageRepository messageRepository;
-    private final ObjectMapper objectMapper;
+  private final MessageRepository messageRepository;
+  private final ObjectMapper objectMapper;
 
-    // 아웃박스 메시지를 생성하고 DB에 저장합니다.
-    public void save(MessageType type, Object event) {
-        Message message = Message.of(type, objectMapper.convertValue(event, JsonNode.class));
-        messageRepository.save(message);
-        log.info("아웃박스 메시지 저장 성공 type={}"   , type);
-    }
+  // 아웃박스 메시지를 생성하고 DB에 저장합니다.
+  public void save(MessageType type, Object event) {
+    String traceId = MDC.get("traceId");
+    Message message = Message.of(type, objectMapper.convertValue(event, JsonNode.class), traceId);
+    messageRepository.save(message);
+  }
 }

--- a/src/main/java/com/gyu/engdu/message/application/MessageRelayService.java
+++ b/src/main/java/com/gyu/engdu/message/application/MessageRelayService.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,28 +22,32 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MessageRelayService {
 
-    private final MessageRepository messageRepository;
-    private final EngduMessagePublisher engduMessagePublisher;
-    private final ObjectMapper objectMapper;
+  private final MessageRepository messageRepository;
+  private final EngduMessagePublisher engduMessagePublisher;
+  private final ObjectMapper objectMapper;
 
-    // 주기마다 NEW 상태의 메시지를 SQS로 발행하고 PUBLISHED로 변경합니다.
-    @Scheduled(fixedDelayString = "${spring.message.relay.delay}")
-    @Transactional
-    public void relayMessages() {
-        List<Message> newMessages = messageRepository.findAllByStatus(MessageStatus.NEW);
+  // 주기마다 NEW 상태의 메시지를 SQS로 발행하고 PUBLISHED로 변경합니다.
+  @Scheduled(fixedDelayString = "${spring.message.relay.delay}")
+  @Transactional
+  public void relayMessages() {
+    MDC.put("suppressSql", "true");
+    try {
+      List<Message> newMessages = messageRepository.findAllByStatus(MessageStatus.NEW);
 
-        for (Message message : newMessages) {
-            try {
-                if (message.getType() == MessageType.GENERATE_ENGDU_PART) {
-                    GenerateEngduPartMessage event = objectMapper.treeToValue(message.getPayload(),
-                            GenerateEngduPartMessage.class);
-                    engduMessagePublisher.publish(event);
-                    message.markPublished(LocalDateTime.now());
-                    log.info("메시지 발행에 성공했습니다. messageId={}", message.getId());
-                }
-            } catch (JsonProcessingException e) {
-                log.error("메시지 역직렬화에 실패했습니다. messageId={}", message.getId(), e);
-            }
+      for (Message message : newMessages) {
+        try {
+          if (message.getType() == MessageType.GENERATE_ENGDU_PART) {
+            GenerateEngduPartMessage event = objectMapper.treeToValue(message.getPayload(),
+                GenerateEngduPartMessage.class);
+            engduMessagePublisher.publish(event, message.getTraceId());
+            message.markPublished(LocalDateTime.now());
+          }
+        } catch (JsonProcessingException e) {
+          log.error("메시지 역직렬화에 실패했습니다. messageId={}", message.getId(), e);
         }
+      }
+    } finally {
+      MDC.remove("suppressSql");
     }
+  }
 }

--- a/src/main/java/com/gyu/engdu/message/domain/Message.java
+++ b/src/main/java/com/gyu/engdu/message/domain/Message.java
@@ -41,19 +41,22 @@ public class Message {
     @Column(columnDefinition = "JSON", nullable = false)
     private JsonNode payload;
 
+    private String traceId;
+
     @CreatedDate
     private LocalDateTime createdAt;
 
     private LocalDateTime publishedAt;
 
-    private Message(MessageType type, JsonNode payload) {
+    private Message(MessageType type, JsonNode payload, String traceId) {
         this.type = type;
         this.payload = payload;
+        this.traceId = traceId;
         this.status = MessageStatus.NEW;
     }
 
-    public static Message of(MessageType type, JsonNode payload) {
-        return new Message(type, payload);
+    public static Message of(MessageType type, JsonNode payload, String traceId) {
+        return new Message(type, payload, traceId);
     }
 
     public void markPublished(LocalDateTime publishedAt) {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,10 +5,20 @@
 
   <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
 
+  <!-- MDC 키가 suppressSql=true 인 경우 전체 로그 레벨을 INFO 이상으로만 강제 허용 (DEBUG, TRACE 차단) -->
+  <turboFilter class="ch.qos.logback.classic.turbo.DynamicThresholdFilter">
+    <Key>suppressSql</Key>
+    <DefaultThreshold>DEBUG</DefaultThreshold>
+    <MDCValueLevelPair>
+      <value>true</value>
+      <level>INFO</level>
+    </MDCValueLevelPair>
+  </turboFilter>
+
   <!-- 로그 포맷 -->
 
   <property name="LOG_PATTERN"
-    value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+    value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%X{traceId}] %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
 
   <springProfile name="local">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/java/com/gyu/engdu/message/MessageTest.java
+++ b/src/test/java/com/gyu/engdu/message/MessageTest.java
@@ -23,7 +23,7 @@ class MessageTest {
         GenerateEngduPartMessage event = GenerateEngduPartMessage.of(1L, 1L, PartType.INITIAL);
 
         // when
-        Message message = Message.of(MessageType.GENERATE_ENGDU_PART, objectMapper.valueToTree(event));
+        Message message = Message.of(MessageType.GENERATE_ENGDU_PART, objectMapper.valueToTree(event), "test-trace-id");
 
         // then
         assertThat(message.getStatus()).isEqualTo(MessageStatus.NEW);
@@ -36,7 +36,7 @@ class MessageTest {
     void markPublished_statusAndPublishedAt() {
         // given
         GenerateEngduPartMessage event = GenerateEngduPartMessage.of(1L, 1L, PartType.INITIAL);
-        Message message = Message.of(MessageType.GENERATE_ENGDU_PART, objectMapper.valueToTree(event));
+        Message message = Message.of(MessageType.GENERATE_ENGDU_PART, objectMapper.valueToTree(event), "test-trace-id");
         LocalDateTime publishedAt = LocalDateTime.of(2026, 3, 20, 12, 0);
 
         // when


### PR DESCRIPTION
## 연관된 이슈

- closed #112

## 작업 내용

### 개요

기존에 로그는 traceId로 요청을 구분하지 않아 동시에 다른 요청이 주어진다면 로그가 혼합되어 추적을 어렵게 했습니다.
이제 요청 단위로 traceId가 주어지고 로그에 traceId를 나타내어 loki에서 traceId를 검색하여 요청이 어떻게 진행되는지 로그를 파악할 수 있도록 개선하려고 합니다.

MDC 로그를 구현하게 된 계기는 [아웃박스패턴 적용하기](https://github.com/eng-du/docs/wiki/%EC%95%84%EC%9B%83-%EB%B0%95%EC%8A%A4-%ED%8C%A8%ED%84%B4%EC%9C%BC%EB%A1%9C-%EB%A9%94%EC%8B%9C%EC%A7%80-%EB%B0%9C%ED%96%89%EA%B3%BC-DB-%EC%A0%95%ED%95%A9%EC%84%B1%EC%9D%84-%EB%B3%B4%EC%9E%A5%ED%95%98%EA%B8%B0) 에서  동시 요청, 난잡한 로그가 디버깅하기 어려웠습니다. DB 정합성 문제가 발생함을 찾기까지의 과정이 불편했고 traceId로 요청 단위를 구분, 검색하여 디버깅 시간을 단축시킬 필요가 있었습니다.


### 변경 사항

MDC 로그 인터셉터를 구현하여 사용자 요청 진입점에 traceId를 만듭니다. 또한, 동일한 인터셉터를 이용해 사용자 요청이 끝날 때 MDC에 저장된 traceId를 삭제합니다.

MDC는 threadlocal을 내부적으로 사용합니다. 쓰레드 풀을 사용하기 떄문에 MDC를 적절히 지우지 않는다면 MDC가 오염되어
의도치않게 작동할 가능성이 있어 주의합니다.

SQS 메시지 발행은 아웃박스 패턴으로 구현되어있습니다. 따라서, message 엔티티에 traceId 컬럼을 추가합니다. relay 로직은 message의 traceId를 이용해 sqs 메시지를 발행할 때 헤더로 traceId를 전송합니다.

SQS 메시지를 수신할 때 traceId를 MDC에 저장합니다.
 

### 주요 고민 및 해결 과정 (선택)

주요 구현은 아래와 같습니다.

- [x] 1. 인터셉터에서 traceId 만들고 MDC.put 하기
- [x] 2. 요청 완료시 인터셉터에서 MDC.remove 하기 
- [x] 3. SQS 비동기 구조에서 traceId 일관되게 사용하도록 만들기
  - [x] 3.1. Message 엔티티에 traceId 삽입
  - [x] 3.2. SQS 메시지에 traceId 삽입
  - [x] 3.3 listener에서 traceId 삽입
  - [x] 3.4 listener 요청이 끝날 때 MDC.remove 하기


#### 일반적인 요청 케이스

<img width="1153" height="136" alt="image" src="https://github.com/user-attachments/assets/c1de57cb-40ac-40c4-bc16-e07412c00a37" />
일반적인 요청일 때 상황입니다. 로그에 traceId가 요청 단위로 잘 나타남을 확인할 수 있습니다. 



#### SQS 비동기 케이스
SQS로 메시지를 발행, 수신할 때 traceId가 정상적으로 유지 되는지 확인해보겠습니다.


<img width="1156" height="59" alt="image" src="https://github.com/user-attachments/assets/e2b8d55a-6070-465a-a0f1-3d6f2e3f5339" />


<img width="1149" height="90" alt="image" src="https://github.com/user-attachments/assets/f0537a66-ed5b-43c9-ae45-6f3d865909bb" />
SQS 메시지 발행하고 수신 작업이 완료될 때 까지 50초가 흘렀습니다. 비동기로 작업 했을 때도 동일한 traceId를 사용하는 것을 확인할 수 있습니다.

