### PR TITLE
[FEAT] AOP로 MDC 저장, 삭제 같은 부가 로직을 비즈니스 로직과 분리

### DIFF
--- a/src/main/java/com/gyu/engdu/config/MdcAspect.java
+++ b/src/main/java/com/gyu/engdu/config/MdcAspect.java
@@ -1,0 +1,55 @@
+package com.gyu.engdu.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class MdcAspect {
+
+  // 메서드 실행 시점에 MDC에 값을 넣고, 메서드 종료 시점에 MDC에서 값을 제거한다.
+  @Around("@annotation(mdcContext)")
+  public Object around(ProceedingJoinPoint joinPoint, MdcContext mdcContext) throws Throwable {
+    String mdcKey = mdcContext.key();
+    String mdcValue = resolveMdcValue(joinPoint, mdcContext);
+
+    if (mdcValue != null) {
+      MDC.put(mdcKey, mdcValue);
+    }
+
+    try {
+      return joinPoint.proceed();
+    } finally {
+      MDC.remove(mdcKey);
+    }
+  }
+
+  // value()가 지정되어 있으면 고정 값을 사용하고, 없으면 paramName()에 해당하는 메서드 파라미터에서 값을 추출한다.
+  private String resolveMdcValue(ProceedingJoinPoint joinPoint, MdcContext mdcContext) {
+    if (!mdcContext.value().isEmpty()) {
+      return mdcContext.value();
+    }
+    return extractFromParam(joinPoint, mdcContext.paramName());
+  }
+
+  // joinpoint 메서드의 파라미터에 해당하는 인자값을 추출한다.
+  private String extractFromParam(ProceedingJoinPoint joinPoint, String paramName) {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    String[] parameterNames = signature.getParameterNames();
+    Object[] args = joinPoint.getArgs();
+
+    for (int i = 0; i < parameterNames.length; i++) {
+      if (paramName.equals(parameterNames[i])) {
+        return args[i].toString();
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/gyu/engdu/config/MdcContext.java
+++ b/src/main/java/com/gyu/engdu/config/MdcContext.java
@@ -1,0 +1,18 @@
+package com.gyu.engdu.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MdcContext {
+
+  // MDC에 넣을 Key
+  String key();
+
+  String paramName() default "";
+
+  String value() default "";
+}

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessageListener.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessageListener.java
@@ -1,5 +1,6 @@
 package com.gyu.engdu.domain.engdu.infra;
 
+import com.gyu.engdu.config.MdcContext;
 import com.gyu.engdu.domain.engdu.application.CreateEngduService;
 import com.gyu.engdu.domain.engdu.application.PartCommandService;
 import com.gyu.engdu.domain.engdu.domain.Part;
@@ -9,7 +10,6 @@ import io.micrometer.core.annotation.Timed;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
@@ -21,42 +21,37 @@ public class EngduSqsMessageListener {
   private final CreateEngduService createEngduService;
   private final PartCommandService partCommandService;
 
+  @MdcContext(key = "traceId", paramName = "traceId")
   @Timed("sqs")
   @SqsListener("${spring.cloud.aws.sqs.queue-name}")
   public void listen(GenerateEngduPartMessage message, @Header(name = "traceId") String traceId) {
-    MDC.put("traceId", traceId);
+    log.info("[SQS 메시지 수신] 잉듀 파트 생성 시작. engduId={}, userId={}, step={}",
+        message.engduId(), message.userId(), message.step());
+
+    // 락 획득, Part 엔티티 CREATING 상태로 변경
+    Optional<Part> partOpt = partCommandService.claimPartCreation(
+        message.engduId(), message.step());
+
+    // 이미 파트가 만들어진 상태이거나 다른 워커가 처리 중이므로 정상 ACK 처리한다.
+    if (partOpt.isEmpty()) {
+      log.info("[SQS 메시지 수신] 이미 잉듀의 파트가 만들어진 상태이거나 다른 워커가 처리중입니다. engduId={}, step={}",
+          message.engduId(), message.step());
+      return;
+    }
+
+    Long partId = partOpt.get().getId();
 
     try {
-      log.info("[SQS 메시지 수신] 잉듀 파트 생성 시작. engduId={}, userId={}, step={}",
-          message.engduId(), message.userId(), message.step());
-
-      // 락 획득, Part 엔티티 CREATING 상태로 변경
-      Optional<Part> partOpt = partCommandService.claimPartCreation(
-          message.engduId(), message.step());
-
-      // 이미 파트가 만들어진 상태이거나 다른 워커가 처리 중이므로 정상 ACK 처리한다.
-      if (partOpt.isEmpty()) {
-        log.info("[SQS 메시지 수신] 이미 잉듀의 파트가 만들어진 상태이거나 다른 워커가 처리중입니다. engduId={}, step={}",
-            message.engduId(), message.step());
-        return;
-      }
-
-      Long partId = partOpt.get().getId();
-
-      try {
-        // 예외 발생 시 SQS가 ACK하지 않고 자동 재시도한다. 3번 재시도 실패한다면 DLQ로 작업을 위임한다.
-        createEngduService.generatePart(partId, message.step());
-        log.info("[SQS 메시지 수신] 잉듀 파트 생성 완료. engduId={}, step={}", message.engduId(),
-            message.step());
-      } catch (Exception e) {
-        // Part 엔티티 FAILED 상태 변경 및 SQS 재시도를 위해 예외 반환
-        partCommandService.markFailed(partId);
-        log.error("[SQS 메시지 수신] 잉듀 파트 생성 실패. engduId={}, step={}", message.engduId(),
-            message.step(), e);
-        throw e;
-      }
-    } finally {
-      MDC.remove("traceId");
+      // 예외 발생 시 SQS가 ACK하지 않고 자동 재시도한다. 3번 재시도 실패한다면 DLQ로 작업을 위임한다.
+      createEngduService.generatePart(partId, message.step());
+      log.info("[SQS 메시지 수신] 잉듀 파트 생성 완료. engduId={}, step={}", message.engduId(),
+          message.step());
+    } catch (Exception e) {
+      // Part 엔티티 FAILED 상태 변경 및 SQS 재시도를 위해 예외 반환
+      partCommandService.markFailed(partId);
+      log.error("[SQS 메시지 수신] 잉듀 파트 생성 실패. engduId={}, step={}", message.engduId(),
+          message.step(), e);
+      throw e;
     }
   }
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessagePublisher.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/EngduSqsMessagePublisher.java
@@ -1,12 +1,12 @@
 package com.gyu.engdu.domain.engdu.infra;
 
+import com.gyu.engdu.config.MdcContext;
 import com.gyu.engdu.domain.engdu.application.EngduMessagePublisher;
 import com.gyu.engdu.domain.engdu.infra.dto.GenerateEngduPartMessage;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -20,20 +20,15 @@ public class EngduSqsMessagePublisher implements EngduMessagePublisher {
   @Value("${spring.cloud.aws.sqs.queue-name}")
   private String queueName;
 
+  @MdcContext(key = "traceId", paramName = "traceId")
   @Timed("sqs")
   public void publish(GenerateEngduPartMessage message, String traceId) {
-    MDC.put("traceId", traceId);
+    sqsTemplate.send(to -> to
+        .queue(queueName)
+        .payload(message)
+        .header("traceId", traceId));
 
-    try {
-      sqsTemplate.send(to -> to
-          .queue(queueName)
-          .payload(message)
-          .header("traceId", traceId));
-
-      log.info("[SQS 메시지 발행] 메시지 발행에 성공했습니다. engduId={}, userId={}, step={}",
-          message.engduId(), message.userId(), message.step());
-    } finally {
-      MDC.remove("traceId");
-    }
+    log.info("[SQS 메시지 발행] 메시지 발행에 성공했습니다. engduId={}, userId={}, step={}",
+        message.engduId(), message.userId(), message.step());
   }
 }

--- a/src/main/java/com/gyu/engdu/message/application/MessageRelayService.java
+++ b/src/main/java/com/gyu/engdu/message/application/MessageRelayService.java
@@ -2,6 +2,7 @@ package com.gyu.engdu.message.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gyu.engdu.config.MdcContext;
 import com.gyu.engdu.domain.engdu.application.EngduMessagePublisher;
 import com.gyu.engdu.domain.engdu.infra.dto.GenerateEngduPartMessage;
 import com.gyu.engdu.message.domain.Message;
@@ -12,7 +13,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,27 +27,23 @@ public class MessageRelayService {
   private final ObjectMapper objectMapper;
 
   // 주기마다 NEW 상태의 메시지를 SQS로 발행하고 PUBLISHED로 변경합니다.
+  @MdcContext(key = "suppressSql", value = "true")
   @Scheduled(fixedDelayString = "${spring.message.relay.delay}")
   @Transactional
   public void relayMessages() {
-    MDC.put("suppressSql", "true");
-    try {
-      List<Message> newMessages = messageRepository.findAllByStatus(MessageStatus.NEW);
+    List<Message> newMessages = messageRepository.findAllByStatus(MessageStatus.NEW);
 
-      for (Message message : newMessages) {
-        try {
-          if (message.getType() == MessageType.GENERATE_ENGDU_PART) {
-            GenerateEngduPartMessage event = objectMapper.treeToValue(message.getPayload(),
-                GenerateEngduPartMessage.class);
-            engduMessagePublisher.publish(event, message.getTraceId());
-            message.markPublished(LocalDateTime.now());
-          }
-        } catch (JsonProcessingException e) {
-          log.error("메시지 역직렬화에 실패했습니다. messageId={}", message.getId(), e);
+    for (Message message : newMessages) {
+      try {
+        if (message.getType() == MessageType.GENERATE_ENGDU_PART) {
+          GenerateEngduPartMessage event = objectMapper.treeToValue(message.getPayload(),
+              GenerateEngduPartMessage.class);
+          engduMessagePublisher.publish(event, message.getTraceId());
+          message.markPublished(LocalDateTime.now());
         }
+      } catch (JsonProcessingException e) {
+        log.error("메시지 역직렬화에 실패했습니다. messageId={}", message.getId(), e);
       }
-    } finally {
-      MDC.remove("suppressSql");
     }
   }
 }


### PR DESCRIPTION
## 연관된 이슈

 - closed #114

## 작업 내용

### 개요

 수동으로 처리하던 MDC(Mapped Diagnostic Context) 데이터 삽입 및 삭제 로직을 AOP 기반의 어노테이션으로 개선하여, 예외 발생 시에도 안전한 컨텍스트 해제를 보장하고 중복되는 코드를 제거했습니다.

이번 작업을 통해 비즈니스 로직과 부가 로직을 분리하여 유지보수성을 높이고 MDC  데이터 삽입 및 삭제 로직에 대해 테스트 코드를 작성할 수 있었습니다.

### 변경 사항

- AOP 기반 MDC 처리를 위한 `@MdcContext` 어노테이션 정의
- `@MdcContext`가 선언된 메서드의 시작과 종료 시점을 가로채는 `MdcAspect` 로직 추가
- 메서드 시작 시점에 지정된 `mdcKey`와 `value` 를 MDC에 안전하게 삽입
- 정상 혹은 예외 종료 시점에 상관없이 안전히 MDC 데이터를 지우도록 동작
- 기존 SQS 메세지 리스너/퍼블리셔, 릴레이 서비스 등에서 사용하던 명시적 `try-finally` 블록 기반의 MDC 처리 코드를 모두 `@MdcContext` 어노테이션으로 깔끔하게 교체
- 통합 테스트 코드 구현으로 AOP가 잘 적용되는지 검증



### 주요 고민 및 해결 과정 (선택)

 - **문제점**: 
 기존에는 비즈니스 로직에서 MDC 로그를 사용하기 위해 반복적으로 `try-finally` 블록을 만들고 `MDC.put` / `MDC.remove`를 직접 호출해야 했습니다. 이런 보일러 플레이트 코드는 3개의 파일에서 중복되고 있었습니다. 또한, 비즈니스 로직과 MDC는 별개의 관심사로 동작이 잘 이루어지는지 테스트하기 어렵다고 생각해 개선이 필요했습니다.
 
 - **해결 과정**: 
 AOP를 도입하여 `@MdcContext` 어노테이션이 붙은 메서드에 `MDC.put` / `MDC.remove`를 동작하도록 만들었습니다. 결과적으로 비즈니스 로직과 부가 로직의 관심사를 분리하여 3개의 파일에 걸친 코드 중복을 제거했습니다. 또한, AOP를 적용하여 보일러 부가 로직에 대해 테스트 가능한 코드를 만들었습니다. `MdcAspectTest`파일에 통합 테스트 코드를 작성하여 AOP 로직이 정상 작동하는지 검증할 수 있습니다.

