### PR TITLE
[FEAT] 해커, 악성 크롤러의 순간적인 공격을 Nginx Rate Limiting으로 방어

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,5 +1,7 @@
 services:
   my-server:
+    mem_limit: 500m
+    cpus: 0.5
     container_name: engdu-app
     restart: unless-stopped
     image: ${IMAGE_NAME}:${IMAGE_TAG}
@@ -13,6 +15,8 @@ services:
       - engdu
 
   promtail:
+    mem_limit: 100m
+    cpus: 0.2
     image: grafana/promtail:latest
     env_file:
       - .env

--- a/compose.infra.yml
+++ b/compose.infra.yml
@@ -1,6 +1,8 @@
 services:
   mysql:
     image: mysql:8.4
+    mem_limit: 300m
+    cpus: 0.5
     container_name: engdu-mysql
     restart: unless-stopped
     env_file:
@@ -19,6 +21,24 @@ services:
       - mysql_data:/var/lib/mysql
     ports:
       - "127.0.0.1:3306:3306"
+    networks:
+      - engdu
+
+  nginx:
+    image: nginx:1.24.0
+    mem_limit: 100m
+    cpus: 0.2
+    container_name: engdu-nginx
+
+    ports:
+      - "80:80"
+      - "443:443"
+
+    volumes:
+      - ./nginx/nginx.local.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/logs:/var/log/nginx
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+
     networks:
       - engdu
 

--- a/nginx/nginx.local.conf
+++ b/nginx/nginx.local.conf
@@ -1,0 +1,31 @@
+events {}
+
+http {
+    # limit requests per IP to 20/sec
+    limit_req_zone $binary_remote_addr zone=ip_limit:10m rate=20r/s;
+    limit_req_status 429;
+
+    upstream spring_backend {
+        server engdu-app:8080;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            limit_req zone=ip_limit burst=20 nodelay;
+            proxy_pass http://spring_backend;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 10s;
+            proxy_send_timeout    10s;
+            proxy_read_timeout    10s;
+            send_timeout          10s;
+        }
+    }
+}

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -1,0 +1,50 @@
+events {}
+
+http {
+    # limit requests per IP to 20/sec
+    limit_req_zone $binary_remote_addr zone=ip_limit:10m rate=20r/s;
+    limit_req_status 429;
+
+    upstream spring_backend {
+        server engdu-app:8080;
+    }
+
+    server {
+        server_name api.engdu.co.kr;
+
+        location / {
+            limit_req zone=ip_limit burst=20 nodelay;
+            proxy_pass http://spring_backend;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 10s;
+            proxy_send_timeout    10s;
+            proxy_read_timeout    10s;
+            send_timeout          10s;
+        }
+
+        listen 443 ssl;
+
+        ssl_certificate     /etc/letsencrypt/live/api.engdu.co.kr/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/api.engdu.co.kr/privkey.pem;
+
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    }
+
+    server {
+        if ($host = api.engdu.co.kr) {
+            return 301 https://$host$request_uri;
+        }
+
+        listen 80;
+        server_name api.engdu.co.kr;
+
+        return 404;
+    }
+
+}


### PR DESCRIPTION
## 연관된 이슈

 - closed #121 

## 작업 내용

### 개요

운영 중 일시적으로 Tomcat 쓰레드풀이 최대치(200개)까지 모두 사용되는 이상 현상을 발견했습니다.  
<img width="666" height="339" alt="image" src="https://github.com/user-attachments/assets/d8489178-24bc-46ce-ba68-6325f8bb829a" />
정상적인 트래픽 패턴에서는 발생하기 어려운 상황이라 판단하여 grafana의 애플리케이션 로그를 분석하였고, `.git/config`와 같은 내부 파일 경로를 반복적으로 조회하는 비정상 요청이 다수 발생하고 있음을 확인했습니다.
<img width="2000"  alt="image" src="https://github.com/user-attachments/assets/1ecddbd3-a91b-409a-a2b7-3951ffce87fa" />


추가로 Nginx access log를 분석한 결과, **특정 IP**에서 300건 이상의 요청을 동시에 전송하는 악의적인 시도가 존재함을 확인했습니다.  

```
34.72.179.167 - - [27/Mar/2026:06:10:56 +0000] "GET /portals/.git/config HTTP/1.1" 404 196 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

34.72.179.167 - - [27/Mar/2026:06:10:56 +0000] "GET /fe/.git/config HTTP/1.1" 404 196 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

34.72.179.167 - - [27/Mar/2026:06:10:56 +0000] "GET /stubs/.git/config HTTP/1.1" 404 196 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

34.72.179.167 - - [27/Mar/2026:06:10:56 +0000] "GET /node-api/.git/config HTTP/1.1" 404 196 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

34.72.179.167 - - [27/Mar/2026:06:10:56 +0000] "GET /settings/.git/config HTTP/1.1" 404 196 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

```

실제 보안 사고로 이어지지는 않았지만, 이러한 요청이 서버의 쓰레드 및 자원을 점유할 경우 정상 사용자의 요청 처리 지연 또는 서비스 불가 상황으로 이어질 수 있는 잠재적인 위험이 있다고 판단했습니다.

이에 따라 Nginx에서 Rate Limiting 기반의 요청 제한 정책을 도입하게 되었습니다.



### 변경 사항

 - `nginx.prod.conf`에 IP 기반 요청 제한 설정 추가
 - `nginx.local.conf`는 nginx.prod.conf 를 개발환경에서 테스트하기 위한 파일임
 - `limit_req_zone`: IP당 초당 20건(`20r/s`)으로 기준 속도 정의
 - `limit_req`: `burst=20`, `nodelay` 옵션을 적용하여 정상적인 사용자의 일시적인 트래픽 폭발(Burst)은 허용하되, 이를 초과하는 악성 트래픽은 `429 Too Many Requests`로 즉시 차단


### 주요 고민 및 해결 과정 (선택)

- **문제점**
  `limit_req`에 `rate`만 단독 적용할 경우, 페이지 로드 시 여러 api 를 동시에 요청하는 정상 트래픽까지 비정상 요청으로 간주되어 `429 Too Many Requests`로 차단될 가능성이 있음을 확인.

- **해결 과정**
  Nginx의 Rate Limiting이 Leaky Bucket 기반으로 동작하며, `rate=20r/s`가 실제로는 "1초에 20개 허용"이 아니라 **약 50ms 간격(1/20초)으로 1개씩 허용되는 방식**으로 계산된다는 점을 고려하여 설정을 조정함.

  이를 기반으로:
  - `$binary_remote_addr` 기준으로 IP 단위 요청 상태를 관리하도록 설정
  - `zone=ip_limit:10m`을 통해 약 16만 개 수준의 IP 요청 상태를 메모리에 저장 가능하도록 구성
  - `burst=20`을 추가하여 순간적인 동시 요청을 최대 20개까지 임시 큐에 보관하도록 설계
  - `nodelay` 옵션을 적용하여 burst 범위 내 요청은 인위적인 지연 없이 즉시 처리하도록 구성

  이를 통해 정상 사용자의 초기 페이지 로딩 시 발생하는 순간적인 요청 집중(Burst)은 허용하면서, 지속적으로 기준 속도를 초과하는 고빈도 요청만 `429 Too Many Requests`로 차단하도록 동작을 조정함.

- **추가 학습 및 고려 사항**
  - Nginx Rate Limiting은 단순 카운터 방식이 아닌 **시간 기반 처리(Leaky Bucket 방식)** 로 동작함을 확인
  - `burst`는 단순 허용량 증가가 아니라 **임시 대기열 역할**을 수행하며,
    `nodelay` 옵션을 통해 사용자 체감 지연 없이 요청을 처리할 수 있음을 검증
  - `zone` 크기(10MB)는 약 16만 개 IP 상태를 저장할 수 있어 현재 서비스 트래픽 규모 대비 충분한 수준으로 판단


<br>

## 개선 결과 검증

개선한 로직이 정상 작동하는지 k6를 사용해 테스트 했습니다.
k6에서 사용한 옵션은 다음과 같습니다. 총 3000건을 요청하는 버스트 환경을 구축했습니다.

```
export const options = {
    vus: 100, 
    iterations: 3000,
};
```
 
### AS IS

#### Nginx Rate Limiting 적용 이전 테스트 결과

Rate Limiting을 적용하기 전에는 요청이 한꺼번에 유입되면서 애플리케이션 서버의 자원이 크게 소모되는 현상이 발생했습니다.

	•	톰캣 스레드 사용량은 최대 120개까지 증가했습니다.
	•	CPU 사용률은 60% 수준까지 상승했습니다.
	•	응답 시간의 중앙값은 597ms, p95 응답 시간은 3.09s로 나타났습니다.

<br>

#### 톰캣 스레드 사용량
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/acfb12bc-e351-4fd3-9a96-872882627a88" />

<br>

#### CPU 사용률
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/2d5f0e0e-ed45-4cae-b397-05375c613168" />

<br>

#### k6 테스트 결과
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/2db77350-e377-4f95-885c-342c49ad7a91" />


<br>

### TO BE

#### Nginx Rate Limiting 적용 이후 테스트 결과

Nginx에 Rate Limiting을 적용한 이후 서버 자원 사용량과 응답 성능이 크게 개선되었습니다.

	•	톰캣 스레드 사용량은 40개 수준으로 감소하여, 이전 대비 약 80개 감소했습니다.
	•	CPU 사용률은 19%로 감소하여, 이전 대비 약 41% 감소했습니다.
	•	응답 시간의 중앙값은 27ms, p95 응답 시간은 66.97ms로 크게 개선되었습니다.

Bucket 사이즈를 초과하는 요청은 애플리케이션까지 도달하지 않고 Nginx에서 429 (Too Many Requests)로 즉시 응답되었기 때문이며, 그 결과 애플리케이션 서버의 스레드와 CPU 자원 사용량이 크게 줄어든 것을 확인할 수 있습니다.


<br>

#### 톰캣 쓰레드 사용량

<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/6d9a4e7e-b18e-4fc3-a103-096c9c3f3a64" />

<br>

#### CPU 사용률
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/4c4fb182-48aa-4e70-896e-1fc3c1ed1830" />


<br>

#### k6 테스트 결과
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e84ca245-fd67-4d33-a576-989ef6f341f7" />

<br>

### 한계점

이번에 발생한 이슈는 동일 IP에서 크롤링 요청이 반복적으로 발생하는 특징을 가지고 있었기 때문에, IP 기반 Rate Limiting만으로도 효과적으로 대응할 수 있었습니다. 

하지만, DDoS 공격과 같이 다수의 클라이언트의 동시 공격은 방어하기 어렵습니다. DDoS 공격은 좀비 PC 또는 분산된 클라이언트를 이용하여 서로 다른 IP 주소에서 대량의 요청을 발생시키는 방식으로 이루어지기 때문에, 단순한 IP 기반 Rate Limiting만으로 방어하기 어렵다는 한계가 있습니다.





