### PR TITLE
[FEAT] 잉듀 페이징 조회 성능 개선을 위한 복합 인덱스 설계

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -114,7 +114,6 @@ CREATE TABLE `message` (
 -- **************************************** TABLE END****************************************
 
 -- **************************************** INDEX START ****************************************
-CREATE INDEX idx_engdu_user_id ON `engdu` (`user_id`);
 CREATE INDEX idx_engdu_user_id_is_all_solved_created_at ON `engdu` (`user_id` ASC, `is_all_solved` ASC, `created_at` DESC);
 CREATE INDEX idx_engdu_user_id_created_at ON `engdu` (`user_id` ASC, `created_at` DESC);
 CREATE INDEX idx_part_engdu_id ON `part` (`engdu_id`);

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -114,6 +114,9 @@ CREATE TABLE `message` (
 -- **************************************** TABLE END****************************************
 
 -- **************************************** INDEX START ****************************************
+CREATE INDEX idx_engdu_user_id ON `engdu` (`user_id`);
+CREATE INDEX idx_engdu_user_id_is_all_solved_created_at ON `engdu` (`user_id` ASC, `is_all_solved` ASC, `created_at` DESC);
+CREATE INDEX idx_engdu_user_id_created_at ON `engdu` (`user_id` ASC, `created_at` DESC);
 CREATE INDEX idx_part_engdu_id ON `part` (`engdu_id`);
 CREATE INDEX idx_article_part_id ON `article` (`part_id`);
 CREATE INDEX idx_article_chunk_article_id ON `article_chunk` (`article_id`);

--- a/src/main/java/com/gyu/engdu/domain/engdu/presentation/dto/response/EngduSummaryResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/presentation/dto/response/EngduSummaryResponse.java
@@ -8,7 +8,6 @@ public record EngduSummaryResponse(
     String title,
     String topic,
     Integer solvedCount,
-    Integer totalCount,
     Boolean isAllSolved,
     LocalDateTime createdAt) {
 
@@ -18,7 +17,6 @@ public record EngduSummaryResponse(
         engdu.getTitle(),
         engdu.getTopic(),
         engdu.getSolvedCount(),
-        (int) engdu.getParts().stream().mapToLong(part -> part.getQuestions().size()).sum(),
         engdu.isAllSolved(),
         engdu.getCreatedAt());
   }


### PR DESCRIPTION
## 연관된 이슈

- closed #123

## 작업 내용

### 개요

 Engdu 테이블의 페이징 조회 성능을 최적화하기 위해 복합 인덱스를 추가하고, 실행 계획에서 발생하던 정렬 성능 저하(Filesort) 문제를 해결했습니다.

### 변경 사항

 - **인덱스 추가 (DDL)**
 - `(user_id, is_all_solved, created_at)` 복합 인덱스 추가 (상태별 필터링용)
 - `(user_id, created_at)` 복합 인덱스 추가 (전체 목록 정렬용)


### 주요 고민 및 해결 과정 

잉듀에서는 메인 화면에서 교육 컨텐츠 페이징 조회를 위해 오프셋 페이징 방식을 사용합니다. 

<img width="2048" height="887" alt="image" src="https://github.com/user-attachments/assets/c0fd44ee-493f-4d6f-9d84-8f3166ba9714" />

오프셋 페이징에서 사용하는 쿼리는 다음과 같습니다.

```jsx
SELECT
    e.engdu_id,
    e.created_at,
    e.is_all_solved,
    e.solved_count,
    e.title,
    e.topic,
FROM engdu e
WHERE
    e.user_id = ?
    AND e.is_all_solved = ?
ORDER BY
    e.created_at
LIMIT ?, ?;
```

등가 조건, 정렬 조건을 고려하여 결과적으로 복합 인덱스를  (user_id asc, is_all_solved asc, created_at desc)로 결정했습니다. 인덱스 선정의 구체적인 과정은 아래의 테스트 결과를 따라서 진행했습니다. 

테스트 환경에서는 조회 대상 테이블에 100만 건의 더미 데이터를 적재했고, 목표는 **TPS 100을 안정적으로 처리**하는 것 입니다. 테스트 대상은 offset 기반 페이징을 사용하는 API이며, 실제 사용자 패턴을 고려하여 사용자가 주로 1번 페이지부터 10번 페이지 사이를 조회한다고 가정하였습니다. 이를 반영하여 page 번호를 랜덤하게 생성하도록 구성했습니다.

또한 테스트 간 랜덤 함수의 일관성을 유지하기 위해 random seed를 고정하여 사용하였으며, 이를 통해 각각의 테스트를 동일한 조건에서 수행할 수 있도록 했습니다.

## filesort 대신 인덱스 정렬 사용하기

### 인덱스 (user_id, is_all_solved) 결과

먼저 `(user_id, is_all_solved)` 복합 인덱스를 생성한 뒤 TPS 100 환경에서 부하 테스트를 수행했습니다.
아래 이미지는 테스트 결과를 그라파나에서 나타낸 것입니다.

<img width="2048" height="637" alt="image" src="https://github.com/user-attachments/assets/a39a618c-e543-4d68-8495-b5b23c04b2c8" />


테스트 결과, 백엔드 서버가 TPS 100을 안정적으로 처리하지 못하고 **TPS 약 60 수준에서 처리량이 제한되는 현상**이 발생하였다. 처리 시간 역시 **p95: 2.85s, 중앙값: 772.87ms** 로 목표 성능을 만족하지 못함을 알 수 있었습니다.

문제의 원인을 파악하기 위해 실행된 쿼리의 **실행 계획**을 확인했습니다.

<img width="2026" height="138" alt="image" src="https://github.com/user-attachments/assets/52ee24a7-c0c3-4255-89be-5bbf1ec3f62e" />


해당 인덱스는 `userId (8byte)` 와 `isAllSolved (1byte)` 로 구성되어 있으며, `key_len` 값을 통해 두 컬럼 모두 정상적으로 인덱스 탐색에 사용되고 있음을 확인할 수 있습니다.

하지만 `Extra` 컬럼에 **Using filesort** 가 표시되어 있었으며, 이는 정렬 과정에서 filesort가 발생했음을 의미합니다. 결국 이 filesort 비용이 전체 성능 저하의 주요 원인으로 판단되었습니다.

> 
> 
> 
> filesort는 정렬을 위해 **추가적인 CPU, 메모리, 디스크 자원을 사용하는 고비용 연산**이다. 인덱스를 활용한 정렬의 경우 이미 정렬된 상태의 데이터를 순차적으로 읽기만 하면 되지만, filesort는 정렬 대상 데이터를 별도의 버퍼에 수집한 뒤 메모리 상에서 정렬을 수행한다. 이때 정렬 대상 데이터가 메모리 버퍼 크기를 초과하면 디스크를 활용한 외부 정렬이 수행되며, 이는 성능에 매우 큰 영향을 줄 수 있다. 
> 

### 인덱스 (user_id, is_all_solved, created_at) 결과

성능을 개선하기 위해 createdAt 컬럼을 기존 인덱스에 추가했습니다. 조회 조건은 아니지만 정렬 조건이기 때문에 사용했고, 실행 계획을 통해 파일 소트가 아닌 인덱스 소트를 사용할 수 있음을 확인했다.

<img width="2048" height="130" alt="image" src="https://github.com/user-attachments/assets/f1119a7b-3e75-4c00-9b4e-70b8dd6a3434" />


다음은 `(user_id, is_all_solved, created_at)` 인덱스를 적용한 뒤 TPS 100 환경의 부하 테스트 결과입니다.

<img width="2048" height="633" alt="image" src="https://github.com/user-attachments/assets/4a12ae9b-9d12-4bab-a743-717abaa38cee" />


해당 인덱스를 적용한 이후 filesort를 제거하고, 정렬 과정이 인덱스 순차 읽기로 대체되면서 전체 응답 시간이 눈에 띄게 개선되는 것을 확인할 수 있었습니다. 처리 시간은 **p95: 25.41ms, 중앙값: 5.65ms** 로 매우 크게 줄었다.

## 내림차순 인덱스로 정방향 스캔 사용하기

### 최종 인덱스 (userId ASC, isAllsolved ASC, createdAt DESC)

일반적으로 사용자들은 최신 데이터를 먼저 조회하는 경우가 많다. 이에 따라 최신 데이터를 빠르게 조회할 수 있도록 내림차순 인덱스를 적용하였다. 

<img width="2048" height="632" alt="image" src="https://github.com/user-attachments/assets/3b51b513-8140-47da-a198-aa0747b8f5ce" />


TPS 100의 테스트 역시 무사히 견뎠다. 처리 시간은 **p95: 13.79ms, 중앙값: 5.20ms** 로 나타났으며, 오름차순 인덱스에 비해 p95는 25.41ms에서 13.79ms 수치로 개선됨을 알 수 있었습니다. 테스트 결과 (userId ASC, isAllsolved ASC, createdAt DESC) 인덱스가 가장 성능이 좋았으며 이를 사용하기로 했습니다.

#### 왜 내림차순 인덱스와 오름차순 인덱스간 성능 차이가 발생할까?

최신 데이터를 조회하는 경우, 내림차순 인덱스는 오름차순 인덱스보다 더 빠른 성능을 보일 수 있습니다. 이는 페이지 내부가 단방향 연결 리스트 형식으로 돼있고 탐색시 **정방향 읽기**를 하기 때문입니다. 

아래의 두 가지 사유로 정방향 스캔은 역방향 스캔에 비해 성능상 유리합니다.

1. 정방향 스캔은 페이지 잠금에 유리한 구조이다.
    
    InnoDB의 페이지 잠금 방식은 정방향 스캔 중심으로 구현돼 있다. innodb는 페이지 잠금 과정에서 데드락을 방지하기 위해서 B-Tree의 왼쪽에서 오른쪽 순서로만 잠금을 획득하도록 구현 돼 있어 역방향 스캔은 복잡한 과정을 거친다.
    
2. 페이지 내부의 데이터는 단일 연결리스트로 연결 되어있다 

<img width="1614" height="866" alt="image" src="https://github.com/user-attachments/assets/65d75504-984e-44d7-9d77-5f008aa5310e" />
    페이지 내부의 레코드는 단일 연결 리스트 구조로 연결되어있다. 정방향 스캔의 경우 연결리스트를 따라가며 자연스럽게 다음 레코드를 읽으면 된다. 하지만, 역방향 스캔의 경우 마지막 레코드부터 읽어야 하며 단방향 연결리스트 구조에서 이전 노드로 가기 위한 방법이 없다. 그래서, 페이지 내부 슬롯 정보를 이용해 이전 레코드 위치를 다시 계산하는 추가적인 연산이 필요하다.

<br>

## 학습 정리
### 복합 인덱스는 무엇인가 ?

DBMS는 데이터 조회 시 인덱스를 하나만 사용한다. 여러 인덱스를 조합해서 사용하는 것 보다 가장 효율적인 인덱스로 탐색하는게 일반적으로 빠르다고 생각하기 때문이다.

복합 인덱스는 조회 쿼리에 여러 조건을 동시에 사용할 때 빠르게 검색하기 위해 사용한다.

### 복합 인덱스 설계시 주의 사항

복합 인덱스를 설계할 때 인덱스 컬럼의 **순서는 매우 중요**하다. MySQL 인덱스는 B-Tree 구조로 
Leftmost Prefix Rule을 사용하기 때문이다. 쉽게 말해 인덱스 내부에서 컬럼 순서대로 정렬되어 있기 때문에 왼쪽부터 사용하는 구조이다.

예를 들어 `INDEX(a, b, c)`  는  (a), (a,b), (a,b,c) 형태의 조건 조회엔 사용할 수 있지만 (b), (b,a,c) 와 같은 순서가 어긋난 구조는 사용하지 못한다.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/242ed24e-81b5-44de-87e4-163b31e10766" />


위에서 알아본 내용으로 복합 인덱스는 컬럼 순서에 따라 활용 가능 여부가 달라진다는 것을 알 수 있다.

그렇다면 어떤 기준으로 컬럼 순서를 정해야 할까? 일반적으로 다음과 같은 우선순위를 따른다.

1. **등가 조건(=)일 경우 Cardinality 고려**
    
    순서에 있어 등가 조건(=)이 최우선으로 배치해야한다. 이때, 등가 조건이 여러 개라면 Cardinality를 고려하여 순서를 정한다. Cardinality는 컬럼 값의 다양성을 의미하며, 값의 종류가 많고 중복이 적을 수록 Cardinality가 높다고 말한다. Cardinality가 높은 컬럼을 앞쪽에 배치하면 인덱스를 탐색할 때 **탐색 범위를 빠르게 줄일 수 있기 때문에 성능상 유리**하다.
    
2. **범위 조건은 등가 조건 뒤에 배치**
    
    범위 조건은 반드시 등가 조건 뒤에 배치해야한다. 등가 조건이 먼저 오면 특정 값을 기준으로 정확히 위치를 찾아갈 수 있다. 이후에 범위 조건이 있다면 필요한 범위를 순차대로 읽으면 된다. 하지만, 범위 조건이 등가 조건보다 앞에 위치한다면 인덱스 탐색은 특정 위치를 찾는게 아니라. 등가 조건에 따라 필터링 처럼 처리해 인덱스를 정상적으로 사용하지 못한다.
    
3. **정렬 조건**
    
    정렬 조건은 조회에 직접 사용하지 않더라도 복합 인덱스에 포함하여 크게 성능 개선을 할 수 있다. 인덱스는 내부적으로 정렬된 구조이다. 정렬해야하는 컬럼이 인덱스에 포함되어 있다면 별도의 정렬 과정 없이 인덱스를 순차대로 읽는 것만으로 정렬 결과를 얻을 수 있다. 
    
    만약 정렬이 필요하지만 인덱스에 포함되어 있지 않다면 DBMS는 filsort와 같은 정렬 작업을 수행하게 된다. 이는 CPU, 메모리, 디스크를 사용하여 정렬하기 때문에 정렬 조건을 인덱스에 포함하는 것이 유용할 수 있다.
    
4. **Covering Index 용 컬럼**
    
    Covering Index는 쿼리 실행 시 필요한 모든 컬럼을 인덱스만으로 조회할 수 있도록 구성된 인덱스이다. 일반적으로 인덱스를 통해 조건에 맞는 행을 찾은 뒤 실제 테이블을 다시 조회하여 부가적인 컬럼 정보를 얻는 Table Lookup 과정이 필요하다. 하지만, Covering Index로 필요한 컬럼이 인덱스에 모두 위치한다면 **Table Lookup 비용을 아낄 수 있다.**
    
    이러한 Covering Index는 조회 조건이나 정렬에 사용하지 않기 때문에 복합 인덱스의 가장 마지막에 배치하는 것이 적절하다.

## 참고자료
https://tech.kakao.com/posts/351
