### PR TITLE
[FEAT] 오프셋 기반 페이징 로직에 커버링 인덱스 적용

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/engdu/application/EngduQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/application/EngduQueryService.java
@@ -1,14 +1,16 @@
 package com.gyu.engdu.domain.engdu.application;
 
+import com.gyu.engdu.domain.engdu.application.dto.response.EngduDetailResponse;
 import com.gyu.engdu.domain.engdu.domain.Engdu;
 import com.gyu.engdu.domain.engdu.domain.EngduRepository;
 import com.gyu.engdu.domain.engdu.domain.enums.EngduSortKey;
 import com.gyu.engdu.domain.engdu.domain.enums.SolvedFilter;
-import com.gyu.engdu.domain.engdu.application.dto.response.EngduDetailResponse;
-import com.gyu.engdu.domain.engdu.presentation.dto.response.EngduSummaryResponse;
 import com.gyu.engdu.domain.engdu.exception.EngduNotFoundException;
+import com.gyu.engdu.domain.engdu.presentation.dto.response.EngduSummaryResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -27,27 +29,33 @@ public class EngduQueryService {
         .orElseThrow(() -> new EngduNotFoundException(id));
   }
 
-  public Page<EngduSummaryResponse> searchEngdu(Long userId, Integer pageNum, Integer size,
+  public Page<EngduSummaryResponse> paginationEngdu(
+      Long userId,
+      Integer pageNum,
+      Integer size,
       EngduSortKey sortKey,
-      Sort.Direction direction, SolvedFilter solvedFilter) {
-    Pageable pageable = PageRequest.of(
-        pageNum,
-        size,
-        Sort.by(direction, sortKey.getProperty()));
+      Sort.Direction direction,
+      SolvedFilter solvedFilter
+  ) {
+    Pageable pageable = createPageable(pageNum, size, sortKey, direction);
 
-    switch (solvedFilter) {
-      case TRUE, FALSE -> {
-        return engduRepository
-            .findAllByUserIdAndIsAllSolved(userId, solvedFilter.getProperty(), pageable)
-            .map(EngduSummaryResponse::from);
-      }
+    // step1: covering index로 빠르게 offset에 해당하는 id 리스트를 조회한다.
+    Page<Long> idsPage = findPagedIds(userId, solvedFilter, pageable);
+    List<Long> ids = idsPage.getContent();
 
-      default -> {
-        return engduRepository
-            .findAllByUserId(userId, pageable)
-            .map(EngduSummaryResponse::from);
-      }
+    // 조회 가능한 id가 없다면 빈 페이지를 반환한다.
+    if (ids.isEmpty()) {
+      return Page.empty(pageable);
     }
+
+    // step2: id 리스트로 engdu 엔티티의 전체 컬럼을 조회한다.
+    List<Engdu> engdus = engduRepository.findByIdIn(ids, pageable.getSort());
+
+    List<EngduSummaryResponse> responses = engdus.stream()
+        .map(EngduSummaryResponse::from)
+        .toList();
+
+    return new PageImpl<>(responses, pageable, idsPage.getTotalElements());
   }
 
   public EngduDetailResponse findDetailEngdu(Long userId, Long engduId) {
@@ -58,5 +66,40 @@ public class EngduQueryService {
 
   public boolean existsEngduByUserId(Long userId) {
     return engduRepository.existsByUserId(userId);
+  }
+
+  // 페이징 조회를 위한 Pageable 인터페이스를 생성한다.
+  private Pageable createPageable(
+      int pageNum,
+      int size,
+      EngduSortKey sortKey,
+      Sort.Direction direction
+  ) {
+    return PageRequest.of(
+        pageNum,
+        size,
+        Sort.by(direction, sortKey.getProperty())
+    );
+  }
+
+  /**
+   * 페이징 조회의 isAllSolved 조건 유무에 따라 쿼리를 다르게 적용한다. 커버링 인덱스를 이용해 offset에 해당하는 id 리스트를 조회한다.
+   */
+  private Page<Long> findPagedIds(
+      Long userId,
+      SolvedFilter solvedFilter,
+      Pageable pageable
+  ) {
+    return switch (solvedFilter) {
+      case TRUE, FALSE -> engduRepository
+          .findIdsByUserIdAndIsAllSolved(
+              userId,
+              solvedFilter.getProperty(),
+              pageable
+          );
+
+      default -> engduRepository
+          .findIdsByUserId(userId, pageable);
+    };
   }
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/domain/EngduRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/domain/EngduRepository.java
@@ -1,16 +1,30 @@
 package com.gyu.engdu.domain.engdu.domain;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EngduRepository extends JpaRepository<Engdu, Long> {
 
-  Page<Engdu> findAllByUserIdAndIsAllSolved(Long userId, Boolean isAllSolved, Pageable pageable);
+  // covering index를 위해 id만 조회한다.
+  @Query("SELECT e.id FROM Engdu e WHERE e.userId = :userId AND e.isAllSolved = :isAllSolved")
+  Page<Long> findIdsByUserIdAndIsAllSolved(
+      @Param("userId") Long userId,
+      @Param("isAllSolved") Boolean isAllSolved,
+      Pageable pageable
+  );
 
-  Page<Engdu> findAllByUserId(Long userId, Pageable pageable);
+  // covering index를 위해 id만 조회한다.
+  @Query("SELECT e.id FROM Engdu e WHERE e.userId = :userId")
+  Page<Long> findIdsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+  List<Engdu> findByIdIn(List<Long> ids, Sort sort);
 
   boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/presentation/EngduController.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/presentation/EngduController.java
@@ -10,8 +10,8 @@ import com.gyu.engdu.domain.engdu.application.SolveQuestionService;
 import com.gyu.engdu.domain.engdu.application.dto.response.CreateEngduResponse;
 import com.gyu.engdu.domain.engdu.application.dto.response.EngduDetailResponse;
 import com.gyu.engdu.domain.engdu.application.dto.response.EngduPartStatusResponse;
-import com.gyu.engdu.domain.engdu.domain.enums.PartType;
 import com.gyu.engdu.domain.engdu.domain.enums.EngduSortKey;
+import com.gyu.engdu.domain.engdu.domain.enums.PartType;
 import com.gyu.engdu.domain.engdu.domain.enums.SolvedFilter;
 import com.gyu.engdu.domain.engdu.presentation.dto.request.CreateEngduRequest;
 import com.gyu.engdu.domain.engdu.presentation.dto.request.LikeEngduRequest;
@@ -84,8 +84,14 @@ public class EngduController {
       @AuthenticationPrincipal(expression = "userId") Long userId) {
     // 클라이언트가 1번 페이지 조회하면 백엔드는 0번 페이지를 조회하도록 하기 위함.
     int adjustedPage = Math.max(0, pageNum - 1);
-    Page<EngduSummaryResponse> responses = engduQueryService.searchEngdu(userId, adjustedPage, size,
-        sortKey, direction, solvedFilter);
+    Page<EngduSummaryResponse> responses = engduQueryService.paginationEngdu(
+        userId,
+        adjustedPage,
+        size,
+        sortKey,
+        direction,
+        solvedFilter
+    );
     boolean hasEngdu = engduQueryService.existsEngduByUserId(userId);
     return ResponseEntity.ok(EngduPageResponse.from(responses, hasEngdu));
   }

--- a/src/test/java/com/gyu/engdu/domain/engdu/application/EngduQueryServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/engdu/application/EngduQueryServiceTest.java
@@ -57,8 +57,14 @@ class EngduQueryServiceTest extends IntegrationTestSupport {
     engduRepository.saveAll(List.of(engdu1, engdu2, engdu3));
 
     // when
-    Page<EngduSummaryResponse> result = engduQueryService.searchEngdu(userId, pageNum, size,
-        engduSortKey, direction, solvedFilter);
+    Page<EngduSummaryResponse> result = engduQueryService.paginationEngdu(
+        userId,
+        pageNum,
+        size,
+        engduSortKey,
+        direction,
+        solvedFilter
+    );
 
     // then
     assertThat(result.getContent()).hasSize(2);
@@ -85,8 +91,14 @@ class EngduQueryServiceTest extends IntegrationTestSupport {
     engduRepository.saveAll(List.of(engdu1, engdu2, engdu3));
 
     // when
-    Page<EngduSummaryResponse> result = engduQueryService.searchEngdu(userId, pageNum, size,
-        engduSortKey, direction, solvedFilter);
+    Page<EngduSummaryResponse> result = engduQueryService.paginationEngdu(
+        userId,
+        pageNum,
+        size,
+        engduSortKey,
+        direction,
+        solvedFilter
+    );
 
     // then
     assertThat(result.getContent()).hasSize(2);
@@ -112,8 +124,14 @@ class EngduQueryServiceTest extends IntegrationTestSupport {
     engduRepository.saveAll(List.of(engdu1, engdu2, engdu3));
 
     // when
-    Page<EngduSummaryResponse> result = engduQueryService.searchEngdu(userId, pageNum, size,
-        engduSortKey, direction, solvedFilter);
+    Page<EngduSummaryResponse> result = engduQueryService.paginationEngdu(
+        userId,
+        pageNum,
+        size,
+        engduSortKey,
+        direction,
+        solvedFilter
+    );
 
     // then
     assertThat(result.getContent()).hasSize(1);


### PR DESCRIPTION
## 연관된 이슈

 - closed #125

## 작업 내용

### 개요
e2e 테스트중 페이지 번호가 뒤로 갈수록 성능 저하가 발생했고 1초 이상의 응답 지연이 문제가 있었습니다. 
Engdu 페이징 조회 시 발생할 수 있는 오프셋(Offset) 성능 지연 문제를 해결하기 위해, 커버링 인덱스를 활용해 성능 최적화를 진행했습니다.

### 변경 사항

- **EngduRepository**
- 커버링 인덱스 스캔을 위해 ID만 조회하는 `findIdsByUserIdAndIsAllSolved`, `findIdsByUserId` 메서드를 추가했습니다.
- 페이징 처리된 ID 리스트를 기반으로 실제 데이터를 정렬하여 가져오는 `findByIdIn` 메서드를 정의했습니다.
- **EngduQueryService**
- 기존 `searchEngdu` 메서드를 `paginationEngdu`로 이름을 변경하고, 페이징 로직의 가독성을 높이기 위해 `createPageable`, `findPagedIds` 등의 프라이빗 메서드로 리팩토링했습니다.
- 2단계 조회 방식 적용: 1단계에서 커버링 인덱스로 빠르게 offset에 해당하는 ID 리스트를 확보한 후, 2단계에서 필요한 엔티티만 `IN` 절로 조회하여 I/O 비용을 최적화했습니다.
- 조회된 ID가 없을 경우 불필요한 추가 쿼리 없이 `Page.empty()`를 즉시 반환하도록 개선했습니다.


## 문제 해결 과정

### OFFSET 기반 페이지네이션

잉듀 서비스는 메인 화면에서 목록 조회를 위해 OFFSET 페이지네이션을 사용하고 있다.  따라서, SQL에서 `LIMIT`과 `OFFSET`을 이용하여 특정 구간의 데이터를 조회하는 방식을 사용중이다.

예를 들어 10개씩 페이지를 조회한다고 하면 다음과 같은 쿼리가 사용된다.

```
SELECT *
FROM engdu
ORDERBY created_at DESC
LIMIT 10 OFFSET 20;
```

이 쿼리는 시간순으로 정렬된 전체 데이터 중 앞에서 20개의 레코드를 읽은 다음 그 다음 10개의 레코드만 반환한다. 이러한 OFFSET 방식의 가장 큰 문제는 앞쪽 레코드를 건너뛰지 않고 실제로 모두 읽는 점이다. 

만약, OFFSET이 매우 크다면 어떻게 될까? 

```
SELECT *
FROM engdu
ORDERBY created_atDESC
LIMIT 10 OFFSET 1000000;
```

이 쿼리를 실행하면 데이터베이스 내부에서는 다음과 같은 작업이 발생한다. 정렬된 레코드를 처음부터 탐색한 뒤 **1,000,000개의 레코드를 읽는다. 읽은** 레코드들은 결과에 포함되지 않으므로 **모두 버리고** 이후 10개의 레코드만 반환한다. 따라서 OFFSET 값이 커질수록 불필요한 디스크 I/O 증가, CPU 사용량 증가 등 성능과 관련된 문제가 발생하게 된다.

### OFFSET 방식을 어떻게 개선할까 ?

버려지는 레코드에 대해 모든 컬럼을 읽지 말자. OFFSET을 탐색하는 과정은 어디부터 데이터를 읽을 지를 찾는 과정이다. 이러한 부가 작업에 실제 레코드의 모든 컬럼을 읽고 올 필요가 없다. 모든 컬럼을 읽는게 성능의 문제인 이유는 세컨드리 인덱스에서 프라이머리 인덱스로 컬럼값을 갖고오는 **테이블 룩업 비용**이 크게 발생하기 때문이다.

 레코드의 모든 컬럼이 필요 없으니 OFFSET을 탐색하는 과정에 커버링 인덱스를 적용시키면 어떨까? 이 방식은 Deferred join(지연 조인) 방식으로 구현할 수 있다.

```jsx
SELECT * 
FROM engdu e 
INNERJOIN (
	-- 1. 서브쿼리: PK(id)만 커버링 인덱스로 빠르게 조회
	SELECT id
	FROM e 
	ORDERBY id 
	LIMIT 20 OFFSET 1000000
)AS temp_e ON e.id = temp_e.id;
```

지연 조인의 예시 쿼리에서 성능 개선이 가능한 포인트는 서브 쿼리 부분에 있다. 서브쿼리에서 커버링 인덱스를 사용해 오프셋을 매우 빠르게 탐색하는 과정에서 속도가 매우 크게 줄어들 것이다.

### 구현 과정

JPA를 사용하는 경우 지연 조인 쿼리를 그대로 구현하는 데 제약이 존재한다. JPA는 FROM 절과 JOIN 절에서 서브쿼리를 지원하지 않는다.  따라서 위의 지연 조인 쿼리의 예시처럼 구현하는 것은 native 쿼리를 사용하지 않는 이상 불가능하다. 

대안으로 성능 개선의 핵심인 커버링 인덱스를 사용하도록 아래의 순서로 쿼리를 실행하도록 했다.

1. 커버링 인덱스를 이용해 **PK(id)만 빠르게 조회**
2. 이후 **실제 필요한 레코드만 테이블에서 조회**

```java
// step1 예시
SELECT e.id
FROM Engdu e
WHERE e.userId = :userId
e.isAllSolved = :isAllSolved
limit 60,6
ORDER BY e.createdAt DESC

// step2 예시
SELECT e FROM Engdu e
WHERE e.id IN (?,?,?)
ORDER BY e.createdAt DESC
```

이 흐름을 구현한 코드는 아래와 같다.  EngduQueryService의 findPageIds 메서드는 EngduRepository를 이용해 PK 리스트를 조회한다. 

```java
// EngduQueryService ... 
   public Page<EngduSummaryResponse> paginationEngdu() { 
  // step1: covering index로 빠르게 offset에 해당하는 id 리스트를 조회한다.
  Page<Long> idsPage = findPagedIds(userId, solvedFilter, pageable);
  List<Long> ids = idsPage.getContent();

  // 조회 가능한 id가 없다면 빈 페이지를 반환한다.
  if (ids.isEmpty()) {
    return Page.empty(pageable);
  }

  // step2: id 리스트로 engdu 엔티티의 전체 컬럼을 조회한다.
  List<Engdu> engdus = engduRepository.findByIdIn(ids, pageable.getSort());

}

// EngduRepository ...

@Query("SELECT e.id FROM Engdu e WHERE e.userId = :userId AND e.isAllSolved = :isAllSolved")
  Page<Long> findIdsByUserIdAndIsAllSolved(
      @Param("userId") Long userId,
      @Param("isAllSolved") Boolean isAllSolved,
      Pageable pageable
  );

```

### 성능 개선 검증

테스트 목표는 TPS 100을 안정적으로 처리할 수 있는 것이다.

테스트 환경은 조회할 page 값이 커 많은 offset을 뛰어 넘어야 할 때 성능 개선을 기대하므로 page 수는 1부터 1000까지 랜덤 함수로 정했다.  랜덤 함수를 사용할 땐 seed를 고정하여  테스트의 일관성을 보장했다.

#### AS IS

<img width="2048" height="636" alt="image" src="https://github.com/user-attachments/assets/70d8ffcb-7e03-4b34-a1cb-224fbb328992" />


- TPS 수치는 60~70을 기록했다.
- 응답 속도에서 중앙값은 659.67ms로 괜찮은 기록이지만 p95가 2.37로 불안정함을 보였다.

#### TO BE

<img width="2048" height="633" alt="image" src="https://github.com/user-attachments/assets/7fec648c-5b10-49b1-98c6-df6dfa655eaf" />

- TPS 100을 안정적으로 처리하고있다.
- 응답 속도에서 중앙값은 15ms, p95는 146.78 ms로 매우 양호했다.
