### PR TITLE
[FIX] 영어 독해 퀴즈 정답의 편향 문제 해결 

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/engdu/application/PartCommandService.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/application/PartCommandService.java
@@ -12,6 +12,9 @@ import com.gyu.engdu.domain.engdu.domain.enums.PartType;
 import com.gyu.engdu.domain.engdu.exception.PartNotFoundException;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +70,12 @@ public class PartCommandService {
         response.questions().forEach(questionDto -> {
             Question question = questionDto.toEntity(part);
             questionDto.choices().forEach(choiceDto -> choiceDto.toEntity(question));
+        });
+
+        part.getQuestions().forEach(question -> {
+            List<Byte> seqs = new ArrayList<>(List.of((byte) 1, (byte) 2, (byte) 3, (byte) 4));
+            Collections.shuffle(seqs);
+            question.shuffleChoices(seqs);
         });
 
         part.changeStatus(PartStatus.DONE);

--- a/src/main/java/com/gyu/engdu/domain/engdu/domain/Choice.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/domain/Choice.java
@@ -50,4 +50,8 @@ public class Choice extends BaseEntity {
     this.question = question;
     question.getChoices().add(this);
   }
+
+  public void changeSeq(Byte seq) {
+    this.seq = seq;
+  }
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/domain/Question.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/domain/Question.java
@@ -17,6 +17,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -48,6 +50,7 @@ public class Question extends BaseEntity {
   private Category category;
 
   @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+  @OrderBy("seq ASC")
   private List<Choice> choices = new ArrayList<>();
 
   @Builder
@@ -92,5 +95,21 @@ public class Question extends BaseEntity {
 
   private void markCorrected() {
     this.isCorrected = true;
+  }
+
+  public void shuffleChoices(List<Byte> seqs) {
+    Choice correctChoice = this.choices.stream()
+        .filter(c -> c.getSeq().equals(this.answer))
+        .findFirst()
+        .orElse(null);
+
+    for (int i = 0; i < this.choices.size(); i++) {
+      Choice choice = this.choices.get(i);
+      byte newSeq = seqs.get(i);
+      choice.changeSeq(newSeq);
+      if (choice == correctChoice) {
+        this.answer = newSeq;
+      }
+    }
   }
 }

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/GptEngduClient.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/GptEngduClient.java
@@ -122,6 +122,7 @@ public class GptEngduClient implements EngduClient {
               - 질문의 선택지(choices)는 반드시 4개여야한다.
               - 질문의 문제 유형을 COMPREHENSION, VOCA, GRAMMAR 중 하나를 선택한다.
               - 해설은 본문의 내용을 기반으로해라. 정답:, 오답:과 같이 불필요한 말들은 제외한다.
+              - 각 선택지의 해설(explanation)에는 특정 보기의 번호나 순서(예: '1번은...', '첫 번째 보기는...')를 지칭하는 표현을 절대 포함하지 말고, 오직 해당 선택지 내용 자체에 대한 해설만 작성해라.
 
           4. 전체 결과는 다음과 같은 JSON 포맷을 따른다:
               응답에는 불필요한 것을 제외하고 순수 JSON으로 준다.
@@ -199,6 +200,7 @@ public class GptEngduClient implements EngduClient {
              - 질문의 선택지(choices)는 반드시 4개여야한다.
              - 질문의 문제 유형을 COMPREHENSION, VOCA, GRAMMAR 중 하나를 선택한다.
              - 해설은 본문의 내용을 기반으로해라. 정답:, 오답:과 같이 불필요한 말들은 제외한다.
+             - 각 선택지의 해설(explanation)에는 특정 번호나 순서(예: '1번은...', '첫 번째 보기는...')를 지칭하는 표현을 절대 포함하지 말고, 오직 해당 선택지 내용 자체에 대한 해설만 작성해라.
 
           3. 전체 결과는 다음과 같은 JSON 포맷을 따른다:
              응답에는 불필요한 것을 제외하고 순수 JSON으로 준다.

--- a/src/test/java/com/gyu/engdu/domain/engdu/domain/PartTest.java
+++ b/src/test/java/com/gyu/engdu/domain/engdu/domain/PartTest.java
@@ -15,131 +15,132 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PartTest {
 
-    @DisplayName("정답을 제출하면 true를 반환한다.")
-    @Test
-    void solveQuestion_correct() {
-        // given
-        Part part = createPart(PartType.INITIAL);
-        byte userAnswer = 1;
-        Long questionId = 1L;
+  @DisplayName("정답을 제출하면 true를 반환한다.")
+  @Test
+  void solveQuestion_correct() {
+    // given
+    Part part = createPart(PartType.INITIAL);
+    byte userAnswer = 1;
+    Long questionId = 1L;
 
-        Question question = mock(Question.class);
-        given(question.getId()).willReturn(questionId);
-        given(question.solve(userAnswer)).willReturn(true);
-        given(question.isCorrected()).willReturn(true); // checkAndMarkAllSolved 호출 시 사용
+    Question question = mock(Question.class);
+    given(question.getId()).willReturn(questionId);
+    given(question.solve(userAnswer)).willReturn(true);
+    given(question.isCorrected()).willReturn(true); // checkAndMarkAllSolved 호출 시 사용
 
-        part.getQuestions().add(question);
+    part.getQuestions().add(question);
 
-        // when
-        boolean result = part.solveQuestion(questionId, userAnswer);
+    // when
+    boolean result = part.solveQuestion(questionId, userAnswer);
 
-        // then
-        assertThat(result).isTrue();
-    }
+    // then
+    assertThat(result).isTrue();
+  }
 
-    @DisplayName("오답을 제출하면 false를 반환한다.")
-    @Test
-    void solveQuestion_wrong() {
-        // given
-        Part part = createPart(PartType.INITIAL);
-        byte wrongAnswer = 2;
-        Long questionId = 1L;
+  @DisplayName("오답을 제출하면 false를 반환한다.")
+  @Test
+  void solveQuestion_wrong() {
+    // given
+    Part part = createPart(PartType.INITIAL);
+    byte wrongAnswer = 2;
+    Long questionId = 1L;
 
-        Question question = mock(Question.class);
-        given(question.getId()).willReturn(questionId);
-        given(question.solve(wrongAnswer)).willReturn(false);
+    Question question = mock(Question.class);
+    given(question.getId()).willReturn(questionId);
+    given(question.solve(wrongAnswer)).willReturn(false);
 
-        part.getQuestions().add(question);
+    part.getQuestions().add(question);
 
-        // when
-        boolean result = part.solveQuestion(questionId, wrongAnswer);
+    // when
+    boolean result = part.solveQuestion(questionId, wrongAnswer);
 
-        // then
-        assertThat(result).isFalse();
-        assertThat(part.isAllSolved()).isFalse();
-    }
+    // then
+    assertThat(result).isFalse();
+    assertThat(part.isAllSolved()).isFalse();
+  }
 
-    @DisplayName("파트에 존재하지 않는 문제를 제출하면 예외가 발생한다.")
-    @Test
-    void solveQuestion_questionNotInPart() {
-        // given
-        Engdu engdu = mock(Engdu.class);
-        given(engdu.getParts()).willReturn(new java.util.ArrayList<>());
-        Part part = Part.of(PartType.INITIAL, engdu);
+  @DisplayName("파트에 존재하지 않는 문제를 제출하면 예외가 발생한다.")
+  @Test
+  void solveQuestion_questionNotInPart() {
+    // given
+    Engdu engdu = mock(Engdu.class);
+    given(engdu.getParts()).willReturn(new java.util.ArrayList<>());
+    Part part = Part.of(PartType.INITIAL, engdu);
 
-        Long existQuestionId = 1L;
-        Long nonExistQuestionId = 99L;
-        byte userAnswer = 1;
+    Long existQuestionId = 1L;
+    Long nonExistQuestionId = 99L;
+    byte userAnswer = 1;
 
-        Question question = mock(Question.class);
-        given(question.getId()).willReturn(existQuestionId);
+    Question question = mock(Question.class);
+    given(question.getId()).willReturn(existQuestionId);
 
-        part.getQuestions().add(question);
+    part.getQuestions().add(question);
 
-        // when & then
-        assertThatThrownBy(() -> part.solveQuestion(nonExistQuestionId, userAnswer))
-                .isInstanceOf(QuestionForbiddenAccessException.class);
-    }
+    // when & then
+    assertThatThrownBy(() -> part.solveQuestion(nonExistQuestionId, userAnswer))
+        .isInstanceOf(QuestionForbiddenAccessException.class);
+  }
 
-    @DisplayName("파트 내 모든 문제를 정답으로 제출하면 isAllSolved가 true가 된다.")
-    @Test
-    void solveAllQuestions_isAllSolvedTrue() {
-        // given
-        Part part = createPart(PartType.INITIAL);
-        byte userAnswer = 1;
+  @DisplayName("파트 내 모든 문제를 정답으로 제출하면 isAllSolved가 true가 된다.")
+  @Test
+  void solveAllQuestions_isAllSolvedTrue() {
+    // given
+    Part part = createPart(PartType.INITIAL);
+    byte userAnswer = 1;
 
-        Question question1 = mock(Question.class);
-        Question question2 = mock(Question.class);
-        given(question1.getId()).willReturn(1L);
-        given(question2.getId()).willReturn(2L);
-        given(question1.solve(userAnswer)).willReturn(true);
-        given(question2.solve(userAnswer)).willReturn(true);
+    Question question1 = mock(Question.class);
+    Question question2 = mock(Question.class);
+    given(question1.getId()).willReturn(1L);
+    given(question2.getId()).willReturn(2L);
+    given(question1.solve(userAnswer)).willReturn(true);
+    given(question2.solve(userAnswer)).willReturn(true);
 
-        // 두 문제 모두 풀린 후 checkAndMarkAllSolved 호출 시 allMatch(isCorrected)에서 사용
-        given(question1.isCorrected()).willReturn(true);
-        given(question2.isCorrected()).willReturn(true);
+    // 두 문제 모두 풀린 후 checkAndMarkAllSolved 호출 시 allMatch(isCorrected)에서 사용
+    given(question1.isCorrected()).willReturn(true);
+    given(question2.isCorrected()).willReturn(true);
 
-        part.getQuestions().add(question1);
-        part.getQuestions().add(question2);
+    part.getQuestions().add(question1);
+    part.getQuestions().add(question2);
 
-        // when
-        part.solveQuestion(1L, userAnswer);
-        part.solveQuestion(2L, userAnswer);
+    // when
+    part.solveQuestion(1L, userAnswer);
+    part.solveQuestion(2L, userAnswer);
 
-        // then
-        assertThat(part.isAllSolved()).isTrue();
-    }
+    // then
+    assertThat(part.isAllSolved()).isTrue();
+  }
 
-    @DisplayName("파트 내 일부 문제만 풀면 isAllSolved가 false로 유지된다.")
-    @Test
-    void solvePartialQuestions_isAllSolvedFalse() {
-        // given
-        Part part = createPart(PartType.INITIAL);
-        byte userAnswer = 1;
+  @DisplayName("파트 내 일부 문제만 풀면 isAllSolved가 false로 유지된다.")
+  @Test
+  void solvePartialQuestions_isAllSolvedFalse() {
+    // given
+    Part part = createPart(PartType.INITIAL);
+    byte userAnswer = 1;
 
-        Question question1 = mock(Question.class);
-        Question question2 = mock(Question.class);
-        given(question1.getId()).willReturn(1L);
-        given(question1.solve(userAnswer)).willReturn(true);
+    Question question1 = mock(Question.class);
+    Question question2 = mock(Question.class);
+    given(question1.getId()).willReturn(1L);
+    given(question1.solve(userAnswer)).willReturn(true);
 
-        // question1만 풀린 후 checkAndMarkAllSolved → allMatch(isCorrected)
-        given(question1.isCorrected()).willReturn(true);
-        given(question2.isCorrected()).willReturn(false); // question2 미해결
+    // question1만 풀린 후 checkAndMarkAllSolved → allMatch(isCorrected)
+    given(question1.isCorrected()).willReturn(true);
+    given(question2.isCorrected()).willReturn(false); // question2 미해결
 
-        part.getQuestions().add(question1);
-        part.getQuestions().add(question2);
+    part.getQuestions().add(question1);
+    part.getQuestions().add(question2);
 
-        // question1만 제출
-        // when
-        part.solveQuestion(question1.getId(), userAnswer);
+    // question1만 제출
+    // when
+    part.solveQuestion(question1.getId(), userAnswer);
 
-        // then
-        assertThat(part.isAllSolved()).isFalse();
-    }
+    // then
+    assertThat(part.isAllSolved()).isFalse();
+  }
 
-    private Part createPart(PartType partType) {
-        return Part.builder()
-                .partType(partType)
-                .build();
-    }
+  private Part createPart(PartType partType) {
+    return Part.builder()
+        .partType(partType)
+        .build();
+  }
+
 }

--- a/src/test/java/com/gyu/engdu/domain/engdu/domain/QuestionTest.java
+++ b/src/test/java/com/gyu/engdu/domain/engdu/domain/QuestionTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.gyu.engdu.domain.engdu.domain.enums.Category;
 import com.gyu.engdu.domain.engdu.exception.QuestionAlreadySolvedException;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -77,6 +78,31 @@ class QuestionTest {
         .answer(answer)
         .isCorrected(isCorrected)
         .build();
+  }
+
+  @DisplayName("shuffleChoices를 호출 시 전달받은 순서대로 선택지들의 seq가 갱신되며 정답 번호도 그에 맞게 갱신된다.")
+  @Test
+  void shuffleChoices() {
+    // given
+    byte correctAnswerSeq = 1;
+    Part part = Part.builder().build();
+    Question question = Question.of(correctAnswerSeq, "질문", Category.COMPREHENSION, part);
+    Choice correctChoice = Choice.of("정답 내용", "정답 해설", correctAnswerSeq, question);
+    Choice wrongChoice1 = Choice.of("오답 내용1", "오답 해설1", (byte) 2, question);
+    Choice wrongChoice2 = Choice.of("오답 내용2", "오답 해설2", (byte) 3, question);
+    Choice wrongChoice3 = Choice.of("오답 내용3", "오답 해설3", (byte) 4, question);
+
+    List<Byte> randomSeqs = List.of((byte) 4, (byte) 1, (byte) 2, (byte) 3);
+
+    // when
+    question.shuffleChoices(randomSeqs);
+
+    // then
+    assertThat(correctChoice.getSeq()).isEqualTo((byte) 4);
+    assertThat(wrongChoice1.getSeq()).isEqualTo((byte) 1);
+    assertThat(wrongChoice2.getSeq()).isEqualTo((byte) 2);
+    assertThat(wrongChoice3.getSeq()).isEqualTo((byte) 3);
+    assertThat(question.getAnswer()).isEqualTo((byte) 4);
   }
 
 }


### PR DESCRIPTION
## 연관된 이슈

- closed #127

## 작업 내용

### 개요

 문제 선택지를 생성할 때 발생하던 정답 편향(answer bias) 문제를 개선했습니다. 

 LLM이 생성하는 해설에 순서를 지칭하는 표현이 들어가지 않도록 프롬프트를 개선했습니다.

 랜덤값 생성은 외부 서비스 레이어에서 구현하고 도메인 레이어에선 값을 바꾸는 식으로 구현해 `Question`에 대한 단위 테스트를 작성 했습니다.

### 변경 사항

 - `GptEngduClient.java`: 
    - LLM 프롬프트에 "특정 보기의 번호나 순서를 지칭하는 표현 절대 포함 금지" 규칙을 추가
    - 섞인 이후에도 해설과 보기가 불일치하지 않도록 개선
 - `Question.java`: 
   - `choices` 연관관계에 `@OrderBy("seq ASC")`를 추가하여, 클라이언트 응답 시 별도 로직 없이 DB 단에서부터 순서대로 정렬되도록 보장
 - `PartCommandService.java`: `Question`마다 1~4의 가변 리스트(`ArrayList`)를 생성하고 셔플하여 `Question.shuffleChoices()`로 넘겨주도록 처리
 - `QuestionTest.java`: 결정적(Deterministic)으로 섞인 순서를 주입받아 제자리에 정확히 맵핑되는지 검증하는 단위 테스트 추가

### 스크린샷 (선택)

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/8f4b928c-4da4-4fde-b3e6-c4b5e9472139" />

20개의 독해 퀴즈를 생성하여 테스트 진행했습니다.
사진을 보면 answer값이 특정 값 (1,2)으로 편향되지 않고 골고루 배포함을 알 수 있습니다.

