### PR TITLE
[FEAT] 런앤런 엔티티 설계와 세션 시작하기, 생성하기 api 구현 

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -111,6 +111,29 @@ CREATE TABLE `message` (
     `trace_id` VARCHAR(255) NULL
 ) ENGINE=InnoDB;
 
+-- RunAndLearnSession Table
+CREATE TABLE `run_and_learn_session` (
+    `run_and_learn_session_id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `user_id` BIGINT,
+    `seed` INT NOT NULL,
+    `score` INT NOT NULL,
+    `started_at` DATETIME(6) NULL,
+    `ended_at` DATETIME(6) NULL,
+    `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB;
+
+-- RunAndLearnQuestion Table
+CREATE TABLE `run_and_learn_question` (
+    `run_and_learn_question_id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `question` VARCHAR(255) NOT NULL,
+    `answer` INT NOT NULL,
+    `choice1` VARCHAR(255) NOT NULL,
+    `choice2` VARCHAR(255) NOT NULL,
+    `choice3` VARCHAR(255) NOT NULL,
+    `explanation` VARCHAR(255) NULL
+) ENGINE=InnoDB;
+
 -- **************************************** TABLE END****************************************
 
 -- **************************************** INDEX START ****************************************
@@ -122,4 +145,5 @@ CREATE INDEX idx_article_chunk_article_id ON `article_chunk` (`article_id`);
 CREATE INDEX idx_question_part_id ON `question` (`part_id`);
 CREATE INDEX idx_choice_question_id ON `choice` (`question_id`);
 CREATE INDEX idx_message_status ON `message` (`status`);
+CREATE INDEX idx_run_and_learn_session_user_id ON `run_and_learn_session` (`user_id`);
 -- **************************************** INDEX END ****************************************

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/CreateRunAndLearnSessionService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/CreateRunAndLearnSessionService.java
@@ -1,0 +1,27 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.user.application.UserQueryService;
+import com.gyu.engdu.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateRunAndLearnSessionService {
+
+    private final UserQueryService userQueryService;
+    private final RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Transactional
+    public Long create(Long userId, int seed) {
+        User user = userQueryService.findExistingUser(userId);
+
+        RunAndLearnSession session = RunAndLearnSession.of(user, seed);
+        runAndLearnSessionRepository.save(session);
+
+        return session.getId();
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/PhrasalVerbQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/PhrasalVerbQueryService.java
@@ -1,9 +1,9 @@
-package com.gyu.engdu.domain.learning.application;
+package com.gyu.engdu.domain.gamification.application;
 
-import com.gyu.engdu.domain.learning.application.dto.PhrasalVerbResponse;
-import com.gyu.engdu.domain.learning.domain.PhrasalVerb;
-import com.gyu.engdu.domain.learning.domain.PhrasalVerbRepository;
-import com.gyu.engdu.domain.learning.exception.PhrasalVerbNotFoundException;
+import com.gyu.engdu.domain.gamification.application.dto.response.PhrasalVerbResponse;
+import com.gyu.engdu.domain.gamification.domain.PhrasalVerb;
+import com.gyu.engdu.domain.gamification.domain.PhrasalVerbRepository;
+import com.gyu.engdu.domain.gamification.exception.PhrasalVerbNotFoundException;
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,8 +30,10 @@ public class PhrasalVerbQueryService {
         return PhrasalVerbResponse.fromEntity(phrasalVerb);
     }
 
-    public PhrasalVerbResponse getPhrasalVerbByPivotAndExclusion(long pivot, Collection<Long> excludedIds) {
-        PhrasalVerb phrasalVerb = phrasalVerbRepository.findFirstByIdGreaterThanEqualAndIdNotIn(pivot, excludedIds);
+    public PhrasalVerbResponse getPhrasalVerbByPivotAndExclusion(long pivot,
+            Collection<Long> excludedIds) {
+        PhrasalVerb phrasalVerb = phrasalVerbRepository.findFirstByIdGreaterThanEqualAndIdNotIn(
+                pivot, excludedIds);
 
         return PhrasalVerbResponse.fromEntity(phrasalVerb);
     }

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
@@ -1,0 +1,21 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RunAndLearnQueryService {
+
+    private final RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    public RunAndLearnSession findExistingSession(Long sessionId) {
+        return runAndLearnSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new RunAndLearnSessionNotFoundException(sessionId));
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/StartRunAndLearnSessionService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/StartRunAndLearnSessionService.java
@@ -1,0 +1,22 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StartRunAndLearnSessionService {
+
+    private final RunAndLearnQueryService runAndLearnQueryService;
+
+    @Transactional
+    public void start(Long userId, Long sessionId, LocalDateTime startTime) {
+        RunAndLearnSession session = runAndLearnQueryService.findExistingSession(sessionId);
+
+        session.validateOwner(userId);
+        session.start(startTime);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/CreateRunAndLearnSessionResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/CreateRunAndLearnSessionResponse.java
@@ -1,0 +1,8 @@
+package com.gyu.engdu.domain.gamification.application.dto.response;
+
+public record CreateRunAndLearnSessionResponse(Long sessionId) {
+
+    public static CreateRunAndLearnSessionResponse of(Long sessionId) {
+        return new CreateRunAndLearnSessionResponse(sessionId);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/PhrasalVerbResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/PhrasalVerbResponse.java
@@ -1,6 +1,6 @@
-package com.gyu.engdu.domain.learning.application.dto;
+package com.gyu.engdu.domain.gamification.application.dto.response;
 
-import com.gyu.engdu.domain.learning.domain.PhrasalVerb;
+import com.gyu.engdu.domain.gamification.domain.PhrasalVerb;
 
 public record PhrasalVerbResponse(
         Long id,

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/PhrasalVerb.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/PhrasalVerb.java
@@ -1,4 +1,4 @@
-package com.gyu.engdu.domain.learning.domain;
+package com.gyu.engdu.domain.gamification.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,21 +19,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = {
-    @UniqueConstraint(name = "unique_phrasalverb_en", columnNames = { "en" })
+        @UniqueConstraint(name = "unique_phrasalverb_en", columnNames = {"en"})
 })
 public class PhrasalVerb {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "phrasal_verb_id")
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "phrasal_verb_id")
+    private Long id;
 
-  private String en;
+    private String en;
 
-  private String kor;
+    private String kor;
 
-  private String exampleSentenceEn;
+    private String exampleSentenceEn;
 
-  private String exampleSentenceKor;
+    private String exampleSentenceKor;
 
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/PhrasalVerbRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/PhrasalVerbRepository.java
@@ -1,4 +1,4 @@
-package com.gyu.engdu.domain.learning.domain;
+package com.gyu.engdu.domain.gamification.domain;
 
 import java.util.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestion.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestion.java
@@ -1,0 +1,34 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunAndLearnQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "speed_quiz_question_id")
+    private Long id;
+
+    private String question;
+
+    private Integer answer;
+
+    private String choice1;
+
+    private String choice2;
+
+    private String choice3;
+
+    private String explanation;
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestion.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestion.java
@@ -16,17 +16,22 @@ public class RunAndLearnQuestion {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "speed_quiz_question_id")
+    @Column(name = "run_and_learn_question_id")
     private Long id;
 
+    @Column(nullable = false)
     private String question;
 
+    @Column(nullable = false)
     private Integer answer;
 
+    @Column(nullable = false)
     private String choice1;
 
+    @Column(nullable = false)
     private String choice2;
 
+    @Column(nullable = false)
     private String choice3;
 
     private String explanation;

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSession.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSession.java
@@ -27,7 +27,7 @@ public class RunAndLearnSession extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "speed_quiz_session_id")
+    @Column(name = "run_and_learn_session_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSession.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSession.java
@@ -1,0 +1,73 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import com.gyu.engdu.domain.BaseEntity;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionAlreadyStartedException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionForbiddenAccessException;
+import com.gyu.engdu.domain.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunAndLearnSession extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "speed_quiz_session_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    private int seed;
+
+    private int score;
+
+    private LocalDateTime startedAt;
+
+    private LocalDateTime endedAt;
+
+    @Builder
+    private RunAndLearnSession(User user, int seed, int score) {
+        this.user = user;
+        this.seed = seed;
+        this.score = score;
+    }
+
+    public static RunAndLearnSession of(User user, int seed) {
+        return RunAndLearnSession.builder()
+                .user(user)
+                .seed(seed)
+                .score(0)
+                .build();
+    }
+
+    public void validateOwner(Long userId) {
+        if (!this.user.getId().equals(userId)) {
+            throw new RunAndLearnSessionForbiddenAccessException(userId, this.id, this.user.getId());
+        }
+    }
+
+    public void start(LocalDateTime startTime) {
+        if (this.startedAt != null) {
+            throw new RunAndLearnSessionAlreadyStartedException(this.id);
+        }
+        this.startedAt = startTime;
+    }
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionRepository.java
@@ -1,0 +1,7 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RunAndLearnSessionRepository extends JpaRepository<RunAndLearnSession, Long> {
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/PhrasalVerbNotFoundException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/PhrasalVerbNotFoundException.java
@@ -1,11 +1,14 @@
-package com.gyu.engdu.domain.learning.exception;
+package com.gyu.engdu.domain.gamification.exception;
 
 import com.gyu.engdu.global.exception.ErrorCode;
 import com.gyu.engdu.global.exception.NotFoundException;
 
 public class PhrasalVerbNotFoundException extends NotFoundException {
+
     public PhrasalVerbNotFoundException() {
-        super(ErrorCode.PHRASAL_NOT_FOUND,
-                "구동사를 찾을 수 없습니다. [데이터베이스가 비어있음]");
+        super(
+                ErrorCode.PHRASAL_NOT_FOUND,
+                "구동사를 찾을 수 없습니다. [데이터베이스가 비어있음]"
+        );
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSessionAlreadyStartedException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSessionAlreadyStartedException.java
@@ -1,0 +1,14 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.ErrorCode;
+import com.gyu.engdu.global.exception.ValidationException;
+
+public class RunAndLearnSessionAlreadyStartedException extends ValidationException {
+
+    public RunAndLearnSessionAlreadyStartedException(Long sessionId) {
+        super(
+                ErrorCode.RUN_AND_LEARN_ALREADY_STARTED,
+                String.format("이미 시작된 스피드 퀴즈 세션입니다. [sessionId=%d]", sessionId)
+        );
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSessionForbiddenAccessException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSessionForbiddenAccessException.java
@@ -1,0 +1,19 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.ErrorCode;
+import com.gyu.engdu.global.exception.ForbiddenException;
+
+public class RunAndLearnSessionForbiddenAccessException extends ForbiddenException {
+
+    public RunAndLearnSessionForbiddenAccessException(Long userId, Long sessionId, Long ownerId) {
+        super(
+                ErrorCode.RUN_AND_LEARN_FORBIDDEN_ACCESS,
+                String.format(
+                        "사용자의 스피드 퀴즈 세션이 아닙니다. [userId=%d, sessionId=%d, ownerId=%d]",
+                        userId,
+                        sessionId,
+                        ownerId
+                )
+        );
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSessionNotFoundException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSessionNotFoundException.java
@@ -1,0 +1,14 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.ErrorCode;
+import com.gyu.engdu.global.exception.NotFoundException;
+
+public class RunAndLearnSessionNotFoundException extends NotFoundException {
+
+    public RunAndLearnSessionNotFoundException(Long sessionId) {
+        super(
+                ErrorCode.RUN_AND_LEARN_NOT_FOUND,
+                String.format("스피드 퀴즈 세션을 찾을 수 없습니다. [sessionId=%d]", sessionId)
+        );
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/presentation/PhrasalVerbController.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/presentation/PhrasalVerbController.java
@@ -1,16 +1,14 @@
-package com.gyu.engdu.domain.learning.presentation;
+package com.gyu.engdu.domain.gamification.presentation;
 
-import com.gyu.engdu.domain.learning.application.PhrasalVerbQueryService;
-import com.gyu.engdu.domain.learning.application.dto.PhrasalVerbResponse;
+import com.gyu.engdu.domain.gamification.application.PhrasalVerbQueryService;
+import com.gyu.engdu.domain.gamification.application.dto.response.PhrasalVerbResponse;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.concurrent.ThreadLocalRandom;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
@@ -1,0 +1,43 @@
+package com.gyu.engdu.domain.gamification.presentation;
+
+import com.gyu.engdu.domain.gamification.application.CreateRunAndLearnSessionService;
+import com.gyu.engdu.domain.gamification.application.StartRunAndLearnSessionService;
+import com.gyu.engdu.domain.gamification.application.dto.response.CreateRunAndLearnSessionResponse;
+import java.time.LocalDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/run-and-learn")
+@RequiredArgsConstructor
+public class RunAndLearnController {
+
+    private final CreateRunAndLearnSessionService createRunAndLearnSessionService;
+    private final StartRunAndLearnSessionService startRunAndLearnSessionService;
+
+    @PostMapping
+    public ResponseEntity<CreateRunAndLearnSessionResponse> createSession(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        int seed = ThreadLocalRandom.current().nextInt();
+        Long sessionId = createRunAndLearnSessionService.create(userId, seed);
+
+        return ResponseEntity.ok(CreateRunAndLearnSessionResponse.of(sessionId));
+    }
+
+    @PostMapping("/{sessionId}/start")
+    public ResponseEntity<Void> startSession(
+            @PathVariable("sessionId") Long sessionId,
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    ) {
+        startRunAndLearnSessionService.start(userId, sessionId, LocalDateTime.now());
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
+++ b/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
@@ -35,8 +35,11 @@ public enum ErrorCode {
   QUESTION_FORBIDDEN_ACCESS("QUESTION-001", "해당 잉듀가 갖고있는 문제가 아닙니다."),
   QUESTION_ALREADY_SOLVED("QUESTION-002", "이미 해결한 문제입니다."),
 
-  // Learning
-  PHRASAL_NOT_FOUND("LEARNING-001", "구동사가 존재하지 않습니다."),
+  // Gamification
+  PHRASAL_NOT_FOUND("GAMIFICATION-001", "구동사가 존재하지 않습니다."),
+  RUN_AND_LEARN_NOT_FOUND("GAMIFICATION-002", "스피드 퀴즈 세션이 존재하지 않습니다."),
+  RUN_AND_LEARN_FORBIDDEN_ACCESS("GAMIFICATION-003", "사용자의 스피드 퀴즈 세션이 아닙니다."),
+  RUN_AND_LEARN_ALREADY_STARTED("GAMIFICATION-004", "이미 시작된 스피드 퀴즈 세션입니다."),
 
   // Spring Standard Errors
   INVALID_INPUT_VALUE("COMMON-001", "잘못된 입력값입니다."),

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/CreateRunAndLearnSessionServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/CreateRunAndLearnSessionServiceTest.java
@@ -1,0 +1,71 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gyu.engdu.IntegrationTestSupport;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.domain.user.domain.UserRepository;
+import com.gyu.engdu.domain.user.exception.UserNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class CreateRunAndLearnSessionServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CreateRunAndLearnSessionService createRunAndLearnSessionService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Test
+    @DisplayName("유저가 세션을 생성하면 DB에 정상적으로 저장되고 ID가 반환된다.")
+    void create1() {
+        // given
+        User user = createUser("test@test.com", "sub123", "testUser");
+        User savedUser = userRepository.save(user);
+
+        int seed = 1234;
+
+        // when
+        Long sessionId = createRunAndLearnSessionService.create(savedUser.getId(), seed);
+
+        // then
+        assertThat(sessionId).isNotNull();
+        RunAndLearnSession session = runAndLearnSessionRepository.findById(sessionId).orElseThrow();
+        assertThat(session.getUser().getId()).isEqualTo(savedUser.getId());
+        assertThat(session.getSeed()).isEqualTo(seed);
+        assertThat(session.getScore()).isZero();
+        assertThat(session.getStartedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저가 세션을 생성하면 예외가 발생한다.")
+    void create2() {
+        // given
+        Long notExistingUserId = 9999L;
+        int seed = 1234;
+
+        // when & then
+        assertThatThrownBy(() -> createRunAndLearnSessionService.create(notExistingUserId, seed))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    private User createUser(String email, String sub, String name) {
+        return User.builder()
+                .email(email)
+                .role(Role.ROLE_USER)
+                .sub(sub)
+                .name(name)
+                .build();
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/PhrasalVerbQueryServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/PhrasalVerbQueryServiceTest.java
@@ -1,4 +1,4 @@
-package com.gyu.engdu.domain.learning.application;
+package com.gyu.engdu.domain.gamification.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryServiceTest.java
@@ -1,0 +1,67 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gyu.engdu.IntegrationTestSupport;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionNotFoundException;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.domain.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class RunAndLearnQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RunAndLearnQueryService runAndLearnQueryService;
+
+    @Autowired
+    private RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("저장된 세션의 ID로 조회하면 정상적으로 엔티티가 반환된다.")
+    void findExistingSession1() {
+        // given
+        User user = createUser("test@test.com", "sub123", "testUser");
+        User savedUser = userRepository.save(user);
+
+        RunAndLearnSession session = RunAndLearnSession.of(savedUser, 1234);
+        RunAndLearnSession savedSession = runAndLearnSessionRepository.save(session);
+
+        // when
+        RunAndLearnSession foundSession = runAndLearnQueryService.findExistingSession(savedSession.getId());
+
+        // then
+        assertThat(foundSession).isNotNull();
+        assertThat(foundSession.getId()).isEqualTo(savedSession.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션 ID로 조회하려 하면 예외가 발생한다.")
+    void findExistingSession2() {
+        // given
+        Long notExistingSessionId = 9999L;
+
+        // when & then
+        assertThatThrownBy(() -> runAndLearnQueryService.findExistingSession(notExistingSessionId))
+                .isInstanceOf(RunAndLearnSessionNotFoundException.class);
+    }
+
+    private User createUser(String email, String sub, String name) {
+        return User.builder()
+                .email(email)
+                .role(Role.ROLE_USER)
+                .sub(sub)
+                .name(name)
+                .build();
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/StartRunAndLearnSessionServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/StartRunAndLearnSessionServiceTest.java
@@ -1,0 +1,102 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gyu.engdu.IntegrationTestSupport;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionAlreadyStartedException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionForbiddenAccessException;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.domain.user.domain.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class StartRunAndLearnSessionServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private StartRunAndLearnSessionService startRunAndLearnSessionService;
+
+    @Autowired
+    private RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("소유자가 런앤런 세션을 시작하면 시작 시간을 저장한다.")
+    void start1() {
+        // given
+        User user = createUser("test@test.com", "sub123", "testUser");
+        User savedUser = userRepository.save(user);
+
+        RunAndLearnSession session = RunAndLearnSession.of(savedUser, 1234);
+        RunAndLearnSession savedSession = runAndLearnSessionRepository.save(session);
+
+        LocalDateTime startTime = LocalDateTime.of(2025, 5, 27, 16, 15);
+
+        // when
+        startRunAndLearnSessionService.start(savedUser.getId(), savedSession.getId(), startTime);
+
+        // then
+        RunAndLearnSession foundSession = runAndLearnSessionRepository.findById(savedSession.getId()).orElseThrow();
+        assertThat(foundSession.getStartedAt()).isEqualTo(startTime);
+    }
+
+    @Test
+    @DisplayName("소유자가 아닌 사용자가 런앤런 세션을 시작하면 예외가 발생한다.")
+    void start2() {
+        // given
+        User owner = createUser("owner@test.com", "sub1", "owner");
+        User otherUser = createUser("other@test.com", "sub2", "other");
+
+        userRepository.save(owner);
+        userRepository.save(otherUser);
+
+        RunAndLearnSession session = RunAndLearnSession.of(owner, 1234);
+        RunAndLearnSession savedSession = runAndLearnSessionRepository.save(session);
+
+        LocalDateTime startTime = LocalDateTime.now();
+
+        // when & then
+        assertThatThrownBy(
+                () -> startRunAndLearnSessionService.start(otherUser.getId(), savedSession.getId(), startTime))
+                .isInstanceOf(RunAndLearnSessionForbiddenAccessException.class);
+    }
+
+    @Test
+    @DisplayName("이미 시작된 세션을 다시 시작하면 예외가 발생한다.")
+    void start3() {
+        // given
+        User owner = createUser("owner@test.com", "sub1", "owner");
+        userRepository.save(owner);
+
+        RunAndLearnSession session = RunAndLearnSession.of(owner, 1234);
+        RunAndLearnSession savedSession = runAndLearnSessionRepository.save(session);
+
+        LocalDateTime firstStartTime = LocalDateTime.of(2023, 1, 1, 10, 0);
+        startRunAndLearnSessionService.start(owner.getId(), savedSession.getId(), firstStartTime);
+
+        LocalDateTime secondStartTime = LocalDateTime.of(2023, 1, 1, 10, 5);
+
+        // when & then
+        assertThatThrownBy(
+                () -> startRunAndLearnSessionService.start(owner.getId(), savedSession.getId(), secondStartTime))
+                .isInstanceOf(RunAndLearnSessionAlreadyStartedException.class);
+    }
+
+    private User createUser(String email, String sub, String name) {
+        return User.builder()
+                .email(email)
+                .role(Role.ROLE_USER)
+                .sub(sub)
+                .name(name)
+                .build();
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionTest.java
@@ -1,0 +1,106 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionAlreadyStartedException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionForbiddenAccessException;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RunAndLearnSessionTest {
+
+    @Test
+    @DisplayName("사용자와 세션 소유자가 일치하면, validateOwner 메서드 검증에 성공한다.")
+    void validateOwner1() {
+        // given
+        Long ownerId = 1L;
+        int seed = 12345;
+        User user = createUser(ownerId);
+
+        RunAndLearnSession session = RunAndLearnSession.of(user, seed);
+
+        // when & then
+        assertThatCode(() -> session.validateOwner(ownerId))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("사용자와 세션 소유자가 다르면, 예외가 발생한다")
+    void validateOwner2() {
+        // given
+        Long ownerId = 1L;
+        Long otherUserId = 2L;
+        int seed = 1234;
+        User user = createUser(ownerId);
+
+        RunAndLearnSession session = RunAndLearnSession.of(user, seed);
+
+        // when & then
+        assertThatThrownBy(() -> session.validateOwner(otherUserId))
+                .isInstanceOf(RunAndLearnSessionForbiddenAccessException.class);
+    }
+
+    @Test
+    @DisplayName("스피드 퀴즈 세션 시작에 성공한다")
+    void start1() {
+        // given
+        User user = createUser(1L);
+        int seed = 12345;
+        LocalDateTime startTime = LocalDateTime.of(2026, 5, 27, 14, 32);
+        RunAndLearnSession session = RunAndLearnSession.of(user, seed);
+
+        // when
+        session.start(startTime);
+
+        // then
+        assertThat(session.getStartedAt()).isEqualTo(startTime);
+    }
+
+    @Test
+    @DisplayName("이미 시작된 세션을 다시 시작하면, 예외가 발생한다")
+    void start2() {
+        // given
+        User user = createUser(1L);
+        int seed = 12345;
+        LocalDateTime startTime = LocalDateTime.of(2023, 1, 1, 0, 0);
+        RunAndLearnSession session = RunAndLearnSession.of(user, seed);
+
+        // 처음 세션 시작
+        session.start(startTime);
+
+        // when & then
+        assertThatThrownBy(() -> session.start(startTime))
+                .isInstanceOf(RunAndLearnSessionAlreadyStartedException.class);
+    }
+
+    @Test
+    @DisplayName("세션 생성 시 score의 초기값은 0이다.")
+    void init() {
+        // given
+        User user = createUser(1L);
+        int seed = 12345;
+
+        // when
+        RunAndLearnSession session = RunAndLearnSession.of(user, seed);
+
+        // then
+        assertThat(session.getScore()).isZero();
+    }
+
+    private User createUser(Long id) {
+        User user = User.builder()
+                .email("test@test.com")
+                .role(Role.ROLE_USER)
+                .sub("sub123")
+                .name("testUser")
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/learning/application/PhrasalVerbQueryServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/learning/application/PhrasalVerbQueryServiceTest.java
@@ -4,10 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.gyu.engdu.IntegrationTestSupport;
-import com.gyu.engdu.domain.learning.application.dto.PhrasalVerbResponse;
-import com.gyu.engdu.domain.learning.domain.PhrasalVerb;
-import com.gyu.engdu.domain.learning.domain.PhrasalVerbRepository;
-import com.gyu.engdu.domain.learning.exception.PhrasalVerbNotFoundException;
+import com.gyu.engdu.domain.gamification.application.PhrasalVerbQueryService;
+import com.gyu.engdu.domain.gamification.application.dto.response.PhrasalVerbResponse;
+import com.gyu.engdu.domain.gamification.domain.PhrasalVerb;
+import com.gyu.engdu.domain.gamification.domain.PhrasalVerbRepository;
+import com.gyu.engdu.domain.gamification.exception.PhrasalVerbNotFoundException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/gyu/engdu/domain/message/MessageTest.java
+++ b/src/test/java/com/gyu/engdu/domain/message/MessageTest.java
@@ -1,4 +1,4 @@
-package com.gyu.engdu.message;
+package com.gyu.engdu.domain.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
## 연관된 이슈

- closed #130

## 작업 내용


### 개요

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/3f6c465c-e89b-4d32-a9c3-e55b5117eac4" />

사진은 런앤런 기능의 사용자 시나리오 흐름입니다. **노란색 영역의 부분을 작업**했습니다.

1. 런앤런(Run And Learn) 기능의 백엔드 엔티티를 설계했습니다.
2. 세션 시작하기, 생성하기 API 개발과 통합 테스트를 작성했습니다.


### 변경 사항

- **패키지 구조 변경**
   - learning 패키지를 gamification 패키지로 네이밍을 변경했습니다.
   - 현재 **구동사 학습하기, 런앤런 기능**이 gamification 패키지에 위치해 있습니다.   
 
- **도메인 엔티티 및 예외 처리 구현**
   - `RunAndLearnSession`, `RunAndLearnQuestion` 엔티티 생성
   - 관련된 커스텀 예외(`...NotFoundException`, `...ForbiddenAccessException`, `...AlreadyStartedException`) 및 `ErrorCode` 추가

- **프레젠테이션 계층 구현** 
   - `/api/v1/run-and-learn` 엔드포인트를 제공하는 `RunAndLearnController` 구현 및 정적 팩토리 메서드를 활용한 DTO 생성

- **단위/통합 테스트 환경 구축**
   - `createUser()` 헬퍼 메서드 및 Builder를 활용하여 테스트 코드의 가독성 개선

### 스크린샷 (선택)
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/43808983-f907-40ae-af0c-d1847a67e432" />
