### PR TITLE
[FEAT] 사용자는 런앤런 문제를 조회할 수 있다.

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
@@ -10,7 +10,9 @@ import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionNotFoundEx
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionNotFoundException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
@@ -53,12 +55,14 @@ public class RunAndLearnQueryService {
 
         List<RunAndLearnQuestion> questions = runAndLearnQuestionRepository.findAllById(questionIds);
 
-        // 오름차순 정렬
-        questions.sort((a, b) -> a.getId().compareTo(b.getId()));
+        // 난수 시퀀스 순서에 맞게 재배치
+        Map<Long, RunAndLearnQuestion> questionMap = questions.stream()
+                .collect(Collectors.toMap(RunAndLearnQuestion::getId, Function.identity()));
 
-        return questions.stream()
-                .map(RunAndLearnQuestionResponse::of)
-                .collect(Collectors.toList());
+        return questionIds.stream()
+                .filter(questionMap::containsKey)
+                .map(id -> RunAndLearnQuestionResponse.from(questionMap.get(id)))
+                .toList();
     }
 
     // 문제의 최대 id를 가져오고 검증

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
@@ -1,8 +1,18 @@
 package com.gyu.engdu.domain.gamification.application;
 
+import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnQuestionResponse;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestionRepository;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionExhaustedException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionNotFoundException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionNotFoundException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,9 +23,53 @@ import org.springframework.transaction.annotation.Transactional;
 public class RunAndLearnQueryService {
 
     private final RunAndLearnSessionRepository runAndLearnSessionRepository;
+    private final RunAndLearnQuestionRepository runAndLearnQuestionRepository;
 
     public RunAndLearnSession findExistingSession(Long sessionId) {
         return runAndLearnSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new RunAndLearnSessionNotFoundException(sessionId));
+    }
+
+    public List<RunAndLearnQuestionResponse> getQuestions(Long userId, Long sessionId,
+            int startIndex,
+            int count) {
+        // 세션 조회 후 사용자 검증
+        RunAndLearnSession session = findExistingSession(sessionId);
+        session.validateOwner(userId);
+
+        Long maxId = validateAndGetMaxId(startIndex);
+
+        // 문제 id 범위 생성
+        List<Long> allIds = LongStream.rangeClosed(1, maxId)
+                .boxed()
+                .collect(Collectors.toList());
+
+        // 시드 기반 문제 순서 섞기
+        int seed = session.getSeed();
+        Collections.shuffle(allIds, new Random(seed));
+
+        int endIndex = Math.min(startIndex + count, maxId.intValue());
+        List<Long> questionIds = allIds.subList(startIndex, endIndex);
+
+        List<RunAndLearnQuestion> questions = runAndLearnQuestionRepository.findAllById(questionIds);
+
+        // 오름차순 정렬
+        questions.sort((a, b) -> a.getId().compareTo(b.getId()));
+
+        return questions.stream()
+                .map(RunAndLearnQuestionResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    // 문제의 최대 id를 가져오고 검증
+    private Long validateAndGetMaxId(int startIndex) {
+        Long maxId = runAndLearnQuestionRepository.findMaxId()
+                .orElseThrow(RunAndLearnQuestionNotFoundException::new);
+
+        if (startIndex >= maxId) {
+            throw new RunAndLearnQuestionExhaustedException();
+        }
+
+        return maxId;
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/RunAndLearnQuestionResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/RunAndLearnQuestionResponse.java
@@ -1,0 +1,25 @@
+package com.gyu.engdu.domain.gamification.application.dto.response;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
+
+public record RunAndLearnQuestionResponse(
+        Long id,
+        String question,
+        Integer answer,
+        String choice1,
+        String choice2,
+        String choice3,
+        String explanation
+) {
+    public static RunAndLearnQuestionResponse of(RunAndLearnQuestion question) {
+        return new RunAndLearnQuestionResponse(
+                question.getId(),
+                question.getQuestion(),
+                question.getAnswer(),
+                question.getChoice1(),
+                question.getChoice2(),
+                question.getChoice3(),
+                question.getExplanation()
+        );
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/RunAndLearnQuestionResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/RunAndLearnQuestionResponse.java
@@ -9,9 +9,8 @@ public record RunAndLearnQuestionResponse(
         String choice1,
         String choice2,
         String choice3,
-        String explanation
-) {
-    public static RunAndLearnQuestionResponse of(RunAndLearnQuestion question) {
+        String explanation) {
+    public static RunAndLearnQuestionResponse from(RunAndLearnQuestion question) {
         return new RunAndLearnQuestionResponse(
                 question.getId(),
                 question.getQuestion(),
@@ -19,7 +18,6 @@ public record RunAndLearnQuestionResponse(
                 question.getChoice1(),
                 question.getChoice2(),
                 question.getChoice3(),
-                question.getExplanation()
-        );
+                question.getExplanation());
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestion.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestion.java
@@ -6,11 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RunAndLearnQuestion {
 

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestionRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestionRepository.java
@@ -1,0 +1,12 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RunAndLearnQuestionRepository extends JpaRepository<RunAndLearnQuestion, Long> {
+
+    @Query("SELECT MAX(q.id) FROM RunAndLearnQuestion q")
+    Optional<Long> findMaxId();
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnQuestionExhaustedException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnQuestionExhaustedException.java
@@ -1,0 +1,14 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.ErrorCode;
+import com.gyu.engdu.global.exception.NotFoundException;
+
+public class RunAndLearnQuestionExhaustedException extends NotFoundException {
+
+    public RunAndLearnQuestionExhaustedException() {
+        super(
+                ErrorCode.RUN_AND_LEARN_QUESTION_EXHAUSTED,
+                "더 이상 런앤런 문제가 남아있지 않습니다."
+        );
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnQuestionNotFoundException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnQuestionNotFoundException.java
@@ -1,0 +1,14 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.ErrorCode;
+import com.gyu.engdu.global.exception.NotFoundException;
+
+public class RunAndLearnQuestionNotFoundException extends NotFoundException {
+
+    public RunAndLearnQuestionNotFoundException() {
+        super(
+                ErrorCode.RUN_AND_LEARN_QUESTION_NOT_FOUND,
+                "런앤런 문제를 찾을 수 없습니다."
+        );
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
@@ -1,13 +1,19 @@
 package com.gyu.engdu.domain.gamification.presentation;
 
 import com.gyu.engdu.domain.gamification.application.CreateRunAndLearnSessionService;
+import com.gyu.engdu.domain.gamification.application.RunAndLearnQueryService;
 import com.gyu.engdu.domain.gamification.application.StartRunAndLearnSessionService;
 import com.gyu.engdu.domain.gamification.application.dto.response.CreateRunAndLearnSessionResponse;
+import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnQuestionResponse;
+import com.gyu.engdu.domain.gamification.presentation.dto.request.RunAndLearnQuestionRequest;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,11 +26,11 @@ public class RunAndLearnController {
 
     private final CreateRunAndLearnSessionService createRunAndLearnSessionService;
     private final StartRunAndLearnSessionService startRunAndLearnSessionService;
+    private final RunAndLearnQueryService runAndLearnQueryService;
 
     @PostMapping
     public ResponseEntity<CreateRunAndLearnSessionResponse> createSession(
-            @AuthenticationPrincipal(expression = "userId") Long userId
-    ) {
+            @AuthenticationPrincipal(expression = "userId") Long userId) {
         int seed = ThreadLocalRandom.current().nextInt();
         Long sessionId = createRunAndLearnSessionService.create(userId, seed);
 
@@ -34,10 +40,25 @@ public class RunAndLearnController {
     @PostMapping("/{sessionId}/start")
     public ResponseEntity<Void> startSession(
             @PathVariable("sessionId") Long sessionId,
-            @AuthenticationPrincipal(expression = "userId") Long userId
-    ) {
+            @AuthenticationPrincipal(expression = "userId") Long userId) {
         startRunAndLearnSessionService.start(userId, sessionId, LocalDateTime.now());
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{sessionId}/question")
+    public ResponseEntity<List<RunAndLearnQuestionResponse>> getQuestions(
+            @PathVariable("sessionId") Long sessionId,
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Valid RunAndLearnQuestionRequest request) {
+
+        List<RunAndLearnQuestionResponse> response = runAndLearnQueryService.getQuestions(
+                userId,
+                sessionId,
+                request.startIndex(),
+                request.count()
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/presentation/dto/request/RunAndLearnQuestionRequest.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/presentation/dto/request/RunAndLearnQuestionRequest.java
@@ -1,0 +1,17 @@
+package com.gyu.engdu.domain.gamification.presentation.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record RunAndLearnQuestionRequest(
+        @NotNull(message = "startIndex는 필수입니다.")
+        @Min(value = 0, message = "startIndex는 0 이상이어야 합니다.")
+        Integer startIndex,
+
+        @NotNull(message = "count는 필수입니다.")
+        @Min(value = 1, message = "count는 1 이상이어야 합니다.")
+        @Max(value = 30, message = "count는 30 이하이어야 합니다.")
+        Integer count
+) {
+}

--- a/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
+++ b/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
@@ -40,6 +40,8 @@ public enum ErrorCode {
   RUN_AND_LEARN_NOT_FOUND("GAMIFICATION-002", "스피드 퀴즈 세션이 존재하지 않습니다."),
   RUN_AND_LEARN_FORBIDDEN_ACCESS("GAMIFICATION-003", "사용자의 스피드 퀴즈 세션이 아닙니다."),
   RUN_AND_LEARN_ALREADY_STARTED("GAMIFICATION-004", "이미 시작된 스피드 퀴즈 세션입니다."),
+  RUN_AND_LEARN_QUESTION_NOT_FOUND("GAMIFICATION-005", "런앤런 문제가 존재하지 않습니다."),
+  RUN_AND_LEARN_QUESTION_EXHAUSTED("GAMIFICATION-006", "더 이상 런앤런 문제가 남아있지 않습니다."),
 
   // Spring Standard Errors
   INVALID_INPUT_VALUE("COMMON-001", "잘못된 입력값입니다."),

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryServiceTest.java
@@ -7,61 +7,181 @@ import com.gyu.engdu.IntegrationTestSupport;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionNotFoundException;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestionRepository;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionExhaustedException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionNotFoundException;
+import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnQuestionResponse;
 import com.gyu.engdu.domain.user.domain.Role;
 import com.gyu.engdu.domain.user.domain.User;
 import com.gyu.engdu.domain.user.domain.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class RunAndLearnQueryServiceTest extends IntegrationTestSupport {
 
-    @Autowired
-    private RunAndLearnQueryService runAndLearnQueryService;
+        @Autowired
+        private RunAndLearnQueryService runAndLearnQueryService;
 
-    @Autowired
-    private RunAndLearnSessionRepository runAndLearnSessionRepository;
+        @Autowired
+        private RunAndLearnSessionRepository runAndLearnSessionRepository;
 
-    @Autowired
-    private UserRepository userRepository;
+        @Autowired
+        private RunAndLearnQuestionRepository runAndLearnQuestionRepository;
 
-    @Test
-    @DisplayName("저장된 세션의 ID로 조회하면 정상적으로 엔티티가 반환된다.")
-    void findExistingSession1() {
-        // given
-        User user = createUser("test@test.com", "sub123", "testUser");
-        User savedUser = userRepository.save(user);
+        @Autowired
+        private UserRepository userRepository;
 
-        RunAndLearnSession session = RunAndLearnSession.of(savedUser, 1234);
-        RunAndLearnSession savedSession = runAndLearnSessionRepository.save(session);
+        @Test
+        @DisplayName("저장된 세션의 ID로 조회하면, 정상적으로 엔티티가 반환된다.")
+        void findExistingSession1() {
+                // given
+                User user = createUser("test@test.com", "sub123", "testUser");
+                User savedUser = userRepository.save(user);
 
-        // when
-        RunAndLearnSession foundSession = runAndLearnQueryService.findExistingSession(savedSession.getId());
+                RunAndLearnSession session = RunAndLearnSession.of(savedUser, 1234);
+                RunAndLearnSession savedSession = runAndLearnSessionRepository.save(session);
 
-        // then
-        assertThat(foundSession).isNotNull();
-        assertThat(foundSession.getId()).isEqualTo(savedSession.getId());
-    }
+                // when
+                RunAndLearnSession foundSession = runAndLearnQueryService.findExistingSession(savedSession.getId());
 
-    @Test
-    @DisplayName("존재하지 않는 세션 ID로 조회하려 하면 예외가 발생한다.")
-    void findExistingSession2() {
-        // given
-        Long notExistingSessionId = 9999L;
+                // then
+                assertThat(foundSession).isNotNull();
+                assertThat(foundSession.getId()).isEqualTo(savedSession.getId());
+        }
 
-        // when & then
-        assertThatThrownBy(() -> runAndLearnQueryService.findExistingSession(notExistingSessionId))
-                .isInstanceOf(RunAndLearnSessionNotFoundException.class);
-    }
+        @Test
+        @DisplayName("존재하지 않는 세션 ID로 조회하려 하면, 예외가 발생한다.")
+        void findExistingSession2() {
+                // given
+                Long notExistingSessionId = 9999L;
 
-    private User createUser(String email, String sub, String name) {
-        return User.builder()
-                .email(email)
-                .role(Role.ROLE_USER)
-                .sub(sub)
-                .name(name)
-                .build();
-    }
+                // when & then
+                assertThatThrownBy(() -> runAndLearnQueryService.findExistingSession(notExistingSessionId))
+                                .isInstanceOf(RunAndLearnSessionNotFoundException.class);
+        }
+
+        private User createUser(String email, String sub, String name) {
+                return User.builder()
+                                .email(email)
+                                .role(Role.ROLE_USER)
+                                .sub(sub)
+                                .name(name)
+                                .build();
+        }
+
+        @Test
+        @DisplayName("데이터베이스에 질문이 하나도 없으면, 예외가 발생한다")
+        void getQuestions1() {
+                // given
+                runAndLearnQuestionRepository.deleteAllInBatch();
+
+                User user = userRepository.save(createUser("test@test.com", "sub123", "testUser"));
+                RunAndLearnSession session = runAndLearnSessionRepository.save(RunAndLearnSession.of(user, 1234));
+
+                // when & then
+                assertThatThrownBy(() -> runAndLearnQueryService.getQuestions(user.getId(), session.getId(), 0, 5))
+                                .isInstanceOf(RunAndLearnQuestionNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("조회 시작 인덱스가 데이터베이스의 최대 문제 ID보다 크거나 같으면, 예외가 발생한다")
+        void getQuestions2() {
+                // given
+                int questionSize = 5;
+                createDummyQuestions(questionSize);
+                User user = userRepository.save(createUser("test2@test.com", "sub456", "testUser2"));
+                RunAndLearnSession session = runAndLearnSessionRepository.save(RunAndLearnSession.of(user, 1234));
+
+                Long maxId = runAndLearnQuestionRepository.findMaxId().get();
+                int startIndex1 = maxId.intValue();
+                int startIndex2 = maxId.intValue() + 10;
+
+                // when & then
+                assertThatThrownBy(() -> runAndLearnQueryService.getQuestions(user.getId(), session.getId(),
+                                startIndex1, 5))
+                                .isInstanceOf(RunAndLearnQuestionExhaustedException.class);
+
+                assertThatThrownBy(() -> runAndLearnQueryService.getQuestions(user.getId(), session.getId(),
+                                startIndex2, 5))
+                                .isInstanceOf(RunAndLearnQuestionExhaustedException.class);
+        }
+
+        @Test
+        @DisplayName("동일한 시드를 가진 세션에서 문제를 조회하면, 같은 문제들이 반환된다")
+        void getQuestions3() {
+                // given
+                createDummyQuestions(15);
+                User user = userRepository.save(createUser("test3@test.com", "sub789", "testUser3"));
+
+                int sameSeed = 777;
+                RunAndLearnSession session1 = runAndLearnSessionRepository.save(RunAndLearnSession.of(user, sameSeed));
+                RunAndLearnSession session2 = runAndLearnSessionRepository.save(RunAndLearnSession.of(user, sameSeed));
+
+                // when
+                List<RunAndLearnQuestionResponse> result1 = runAndLearnQueryService.getQuestions(user.getId(),
+                                session1.getId(),
+                                0, 10);
+                List<RunAndLearnQuestionResponse> result2 = runAndLearnQueryService.getQuestions(user.getId(),
+                                session2.getId(),
+                                0, 10);
+
+                // then
+                List<Long> ids1 = result1.stream().map(RunAndLearnQuestionResponse::id).collect(Collectors.toList());
+                List<Long> ids2 = result2.stream().map(RunAndLearnQuestionResponse::id).collect(Collectors.toList());
+
+                assertThat(ids1).containsExactlyElementsOf(ids2);
+        }
+
+        @Test
+        @DisplayName("다른 시드를 가진 세션에서 문제를 조회하면 다른 문제들이 반환된다")
+        void getQuestions4() {
+                // given
+                createDummyQuestions(15);
+                User user = userRepository.save(createUser("test4@test.com", "sub000", "testUser4"));
+
+                int seed = 111;
+                int anotherSeed = 222;
+
+                RunAndLearnSession session1 = runAndLearnSessionRepository.save(RunAndLearnSession.of(user, seed));
+                RunAndLearnSession session2 = runAndLearnSessionRepository
+                                .save(RunAndLearnSession.of(user, anotherSeed));
+
+                // when
+                List<RunAndLearnQuestionResponse> result1 = runAndLearnQueryService.getQuestions(user.getId(),
+                                session1.getId(),
+                                0, 10);
+                List<RunAndLearnQuestionResponse> result2 = runAndLearnQueryService.getQuestions(user.getId(),
+                                session2.getId(),
+                                0, 10);
+
+                // then
+                List<Long> ids1 = result1.stream().map(RunAndLearnQuestionResponse::id).collect(Collectors.toList());
+                List<Long> ids2 = result2.stream().map(RunAndLearnQuestionResponse::id).collect(Collectors.toList());
+
+                assertThat(ids1).isNotEqualTo(ids2);
+        }
+
+        private void createDummyQuestions(int count) {
+
+                List<RunAndLearnQuestion> questions = IntStream.range(0, count)
+                                .mapToObj(i -> RunAndLearnQuestion.builder()
+                                                .question("Question " + i)
+                                                .answer(1)
+                                                .choice1("Choice 1")
+                                                .choice2("Choice 2")
+                                                .choice3("Choice 3")
+                                                .explanation("Explanation " + i)
+                                                .build())
+                                .collect(Collectors.toList());
+                runAndLearnQuestionRepository.saveAll(questions);
+        }
 }


### PR DESCRIPTION
## 연관된 이슈

- closed #132

## 작업 내용

### 개요

런앤런 세션의 고유 Seed 값을 활용하여 문제 풀을 일관되게 셔플하고, 난수 시퀀스를 자른 뒤 해당하는 PK 목록으로 문제를 랜덤하게 페이징 조회할 수 있는 API를 구현했습니다.

세션의 고유 Seed를 이용해 셔플하므로 모든 세션마다 각각의 문제가 다르게 나올 것을 기대합니다. 
또한, 세션의 점수 검증이 용이합니다. 서버는 seed를 통해 세션 내에서 사용자가 해결했거나 받을 문제를 알 수 있습니다.
사용자가 제출한 답안 리스트와 문제들의 답이 정말로 맞는지 2차 검증을 할 수 있습니다.

### 변경 사항

- **런앤런 문제 조회 API 추가 및 요청 검증** (`RunAndLearnController`)
  - `GET /api/v1/run-and-learn/{sessionId}/question` 엔드포인트 추가
  - `@Valid`와 DTO(Request)를 통해 `startIndex` (0 이상), `count` (1 ~ 30 범위) 파라미터 유효성 검증 적용

- **일관성 있는 난수 셔플 및 페이징 비즈니스 로직 구현** (`RunAndLearnQueryService`)
  - `maxId`를 조회하여 `1 ~ maxId` 범위의 ID 목록 생성 후, 세션 Seed 기반으로 셔플 수행
  - 셔플된 전체 ID 목록 중 `[startIndex, endIndex)` 구간의 문제 ID 추출
  - 추출된 ID로 일괄 DB 조회 및 ID 기준 오름차순 정렬 후 DTO 반환
  - 문제 개수 및 조회 범위 초과에 따른 예외 처리 추가 및 별도 검증 메서드로 분리 (`validateAndGetMaxId`)
- **문제 최대 ID 조회 기능 정의** (`RunAndLearnQuestionRepository`)
  - `MAX(id)` 쿼리를 사용하여 테이블 내 가장 큰 PK 값을 가져오는 `findMaxId` 정의
- **API 응답 DTO 추가** (`RunAndLearnQuestionResponse`)
  - 클라이언트에 반환할 문제(id, question, answer, choices, explanation) 포맷 정의
- **예외 클래스 및 에러 코드 추가** (`RunAndLearnQuestionNotFoundException`, `RunAndLearnQuestionExhaustedException`, `ErrorCode`)
  - `GAMIFICATION-005` (런앤런 문제가 존재하지 않을 때)
  - `GAMIFICATION-006` (요청 범위가 유효한 문제 범위를 초과했을 때)
