### PR TITLE
fix: api 요청 validation 예외 상황 시 원인 메시지를 정상적으로 보내도록 수정

### DIFF
--- a/src/main/java/com/gyu/engdu/global/exception/ErrorResponseEntity.java
+++ b/src/main/java/com/gyu/engdu/global/exception/ErrorResponseEntity.java
@@ -9,17 +9,29 @@ import org.springframework.http.ResponseEntity;
 @Getter
 // TODO: ProblemDetail로 개선하기
 public class ErrorResponseEntity {
-  private int status;
-  private String code;
-  private String message;
 
-  public static ResponseEntity<ErrorResponseEntity> toResponseEntity(ErrorCode errorCode, HttpStatus httpStatus) {
-    return ResponseEntity
-        .status(httpStatus)
-        .body(ErrorResponseEntity.of(errorCode, httpStatus));
-  }
+    private int status;
+    private String code;
+    private String message;
 
-  public static ErrorResponseEntity of(ErrorCode errorCode, HttpStatus httpStatus) {
-    return new ErrorResponseEntity(httpStatus.value(), errorCode.getCode(), errorCode.getMessage());
-  }
+    public static ResponseEntity<ErrorResponseEntity> toResponseEntity(ErrorCode errorCode,
+            HttpStatus httpStatus) {
+        return ResponseEntity
+                .status(httpStatus)
+                .body(ErrorResponseEntity.of(errorCode, httpStatus));
+    }
+
+    public static ResponseEntity<ErrorResponseEntity> toResponseEntity(ErrorCode errorCode,
+            String customMessage,
+            HttpStatus httpStatus) {
+        return ResponseEntity
+                .status(httpStatus)
+                .body(new ErrorResponseEntity(httpStatus.value(), errorCode.getCode(),
+                        customMessage));
+    }
+
+    public static ErrorResponseEntity of(ErrorCode errorCode, HttpStatus httpStatus) {
+        return new ErrorResponseEntity(httpStatus.value(), errorCode.getCode(),
+                errorCode.getMessage());
+    }
 }

--- a/src/main/java/com/gyu/engdu/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gyu/engdu/global/exception/GlobalExceptionHandler.java
@@ -50,8 +50,10 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(org.springframework.web.bind.MethodArgumentNotValidException.class)
   protected ResponseEntity<ErrorResponseEntity> handleMethodArgumentNotValid(
       org.springframework.web.bind.MethodArgumentNotValidException e) {
-    log.warn("Validation 에러: {}", e.getBindingResult().getAllErrors());
-    return ErrorResponseEntity.toResponseEntity(ErrorCode.INVALID_INPUT_VALUE, HttpStatus.BAD_REQUEST);
+    // 첫번째 에러의 메시지를 사용자에게 반환
+    String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+    log.warn("Validation 에러: {}", errorMessage);
+    return ErrorResponseEntity.toResponseEntity(ErrorCode.INVALID_INPUT_VALUE, errorMessage, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(org.springframework.web.servlet.NoHandlerFoundException.class)


### PR DESCRIPTION
## 연관된 이슈
- closed 136

## 작업 내용

### 개요

DTO 필드 검증(Validation) 실패 시 기본 에러 메시지가 아닌, DTO 필드에 정의한 커스텀 에러 메시지를 응답하도록 예외 처리 로직을 개선했습니다.

### 스크린샷
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f1c05644-5099-4c81-bb7d-50e52774f852" />

### 변경 사항

- **ErrorResponseEntity**
  - 커스텀 에러 메시지를 포함해 응답 엔티티를 생성할 수 있도록 `toResponseEntity` 오버로딩 메서드 추가
- **GlobalExceptionHandler**
  - `MethodArgumentNotValidException` 발생 시, 여러 검증 오류 중 첫 번째 오류의 기본 메시지(`defaultMessage`)를 추출하여 응답하도록 처리 방식 수정
