### PR TITLE
[FEAT] 사용자는 런앤런 세션을 종료할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	//카페인 캐시
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
+
 	//AWS SQS
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:3.3.0'
 	implementation 'software.amazon.awssdk:sqs:2.29.52'

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/EndRunAndLearnSessionService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/EndRunAndLearnSessionService.java
@@ -1,0 +1,65 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import com.gyu.engdu.domain.gamification.application.dto.request.EndRunAndLearnSessionRequest;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnEndValidationService;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestionRepository;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.exception.InvalidRunAndLearnPlayException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EndRunAndLearnSessionService {
+
+    private final RunAndLearnQueryService runAndLearnQueryService;
+    private final RunAndLearnQuestionRepository runAndLearnQuestionRepository;
+    private final RunAndLearnEndValidationService runAndLearnEndValidationService;
+
+    public void endSession(Long userId, Long sessionId, EndRunAndLearnSessionRequest request,
+            LocalDateTime endTime) {
+        RunAndLearnSession session = runAndLearnQueryService.findExistingSession(sessionId);
+        session.validateOwner(userId);
+
+        Long maxId = runAndLearnQuestionRepository.findMaxId()
+                .orElseThrow(RunAndLearnQuestionNotFoundException::new);
+
+        int submitCount = request.submittedAnswers().size();
+
+        if (submitCount > maxId) {
+            throw new InvalidRunAndLearnPlayException("제출된 답변 수가 전체 문제 수보다 많습니다.");
+        }
+
+        List<Long> expectedSequence = LongStream.rangeClosed(1, maxId)
+                .boxed()
+                .collect(Collectors.toList());
+
+        Collections.shuffle(expectedSequence, new Random(session.getSeed()));
+
+        List<Long> expectedQuestionIds = expectedSequence.subList(0, submitCount);
+
+        List<RunAndLearnQuestion> expectedQuestions = runAndLearnQueryService
+                .getQuestionAndRestoreOrder(expectedQuestionIds);
+
+        runAndLearnEndValidationService.validate(
+                session,
+                maxId,
+                request.submittedAnswers(),
+                expectedQuestions,
+                request.clientTotalScore());
+
+        session.end(request.clientTotalScore(), endTime);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/EndRunAndLearnSessionService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/EndRunAndLearnSessionService.java
@@ -1,18 +1,13 @@
 package com.gyu.engdu.domain.gamification.application;
 
+import com.gyu.engdu.domain.gamification.application.cache.RunAndLearnCacheService;
 import com.gyu.engdu.domain.gamification.application.dto.request.EndRunAndLearnSessionRequest;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnEndValidationService;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
-import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestionRepository;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
 import com.gyu.engdu.domain.gamification.exception.InvalidRunAndLearnPlayException;
-import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionNotFoundException;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
-import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,41 +20,44 @@ import org.springframework.transaction.annotation.Transactional;
 public class EndRunAndLearnSessionService {
 
     private final RunAndLearnQueryService runAndLearnQueryService;
-    private final RunAndLearnQuestionRepository runAndLearnQuestionRepository;
+    private final RunAndLearnCacheService runAndLearnCacheService;
     private final RunAndLearnEndValidationService runAndLearnEndValidationService;
 
     public void endSession(Long userId, Long sessionId, EndRunAndLearnSessionRequest request,
             LocalDateTime endTime) {
+        // 세션 조회 및 소유자 검증
         RunAndLearnSession session = runAndLearnQueryService.findExistingSession(sessionId);
         session.validateOwner(userId);
 
-        Long maxId = runAndLearnQuestionRepository.findMaxId()
-                .orElseThrow(RunAndLearnQuestionNotFoundException::new);
+        // 캐시에서 세션의 문제 순서 가져오기
+        List<Long> expectedSessionQuestionIds = runAndLearnCacheService.getSessionQuestionIds(sessionId,
+                session.getSeed());
 
+        int totalQuestions = expectedSessionQuestionIds.size();
         int submitCount = request.submittedAnswers().size();
 
-        if (submitCount > maxId) {
-            throw new InvalidRunAndLearnPlayException("제출된 답변 수가 전체 문제 수보다 많습니다.");
-        }
+        // 제출한 문제 수 오류 검증
+        validateSubmitCount(submitCount, totalQuestions);
 
-        List<Long> expectedSequence = LongStream.rangeClosed(1, maxId)
-                .boxed()
-                .collect(Collectors.toList());
-
-        Collections.shuffle(expectedSequence, new Random(session.getSeed()));
-
-        List<Long> expectedQuestionIds = expectedSequence.subList(0, submitCount);
+        List<Long> targetQuestionIds = expectedSessionQuestionIds.subList(0, submitCount);
 
         List<RunAndLearnQuestion> expectedQuestions = runAndLearnQueryService
-                .getQuestionAndRestoreOrder(expectedQuestionIds);
+                .getQuestionAndRestoreOrder(targetQuestionIds);
 
         runAndLearnEndValidationService.validate(
                 session,
-                maxId,
+                totalQuestions,
                 request.submittedAnswers(),
                 expectedQuestions,
                 request.clientTotalScore());
 
         session.end(request.clientTotalScore(), endTime);
+        runAndLearnCacheService.removeSessionQuestionIds(sessionId);
+    }
+
+    private void validateSubmitCount(int submitCount, int totalQuestions) {
+        if (submitCount > totalQuestions) {
+            throw new InvalidRunAndLearnPlayException("제출된 답변 수가 전체 문제 수보다 많습니다.");
+        }
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
@@ -32,7 +32,9 @@ public class RunAndLearnQueryService {
                 .orElseThrow(() -> new RunAndLearnSessionNotFoundException(sessionId));
     }
 
-    public List<RunAndLearnQuestionResponse> getQuestions(Long userId, Long sessionId,
+    public List<RunAndLearnQuestionResponse> getQuestions(
+            Long userId,
+            Long sessionId,
             int startIndex,
             int count) {
         // 세션 조회 후 사용자 검증
@@ -53,15 +55,10 @@ public class RunAndLearnQueryService {
         int endIndex = Math.min(startIndex + count, maxId.intValue());
         List<Long> questionIds = allIds.subList(startIndex, endIndex);
 
-        List<RunAndLearnQuestion> questions = runAndLearnQuestionRepository.findAllById(questionIds);
+        List<RunAndLearnQuestion> questions = getQuestionAndRestoreOrder(questionIds);
 
-        // 난수 시퀀스 순서에 맞게 재배치
-        Map<Long, RunAndLearnQuestion> questionMap = questions.stream()
-                .collect(Collectors.toMap(RunAndLearnQuestion::getId, Function.identity()));
-
-        return questionIds.stream()
-                .filter(questionMap::containsKey)
-                .map(id -> RunAndLearnQuestionResponse.from(questionMap.get(id)))
+        return questions.stream()
+                .map(RunAndLearnQuestionResponse::from)
                 .toList();
     }
 
@@ -75,5 +72,20 @@ public class RunAndLearnQueryService {
         }
 
         return maxId;
+    }
+
+    /**
+     * questionId 순서에 맞게 가져오기. findAllById는 순서를 보장하지 않기 때문에 Map을 사용해서 정렬
+     */
+    public List<RunAndLearnQuestion> getQuestionAndRestoreOrder(List<Long> questionIds) {
+        List<RunAndLearnQuestion> questions = runAndLearnQuestionRepository.findAllById(
+                questionIds);
+        Map<Long, RunAndLearnQuestion> questionMap = questions.stream()
+                .collect(Collectors.toMap(RunAndLearnQuestion::getId, Function.identity()));
+
+        return questionIds.stream()
+                .filter(questionMap::containsKey)
+                .map(questionMap::get)
+                .toList();
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnQueryService.java
@@ -1,5 +1,6 @@
 package com.gyu.engdu.domain.gamification.application;
 
+import com.gyu.engdu.domain.gamification.application.cache.RunAndLearnCacheService;
 import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnQuestionResponse;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestionRepository;
@@ -8,13 +9,10 @@ import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionExhaustedException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnQuestionNotFoundException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionNotFoundException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +24,7 @@ public class RunAndLearnQueryService {
 
     private final RunAndLearnSessionRepository runAndLearnSessionRepository;
     private final RunAndLearnQuestionRepository runAndLearnQuestionRepository;
+    private final RunAndLearnCacheService runAndLearnCacheService;
 
     public RunAndLearnSession findExistingSession(Long sessionId) {
         return runAndLearnSessionRepository.findById(sessionId)
@@ -41,19 +40,21 @@ public class RunAndLearnQueryService {
         RunAndLearnSession session = findExistingSession(sessionId);
         session.validateOwner(userId);
 
-        Long maxId = validateAndGetMaxId(startIndex);
+        // 캐시를 통해 문제 순서 가져오기
+        List<Long> sessionQuestionIds = runAndLearnCacheService.getSessionQuestionIds(sessionId,
+                session.getSeed());
+        int totalQuestions = sessionQuestionIds.size();
 
-        // 문제 id 범위 생성
-        List<Long> allIds = LongStream.rangeClosed(1, maxId)
-                .boxed()
-                .collect(Collectors.toList());
+        if (totalQuestions == 0) {
+            throw new RunAndLearnQuestionNotFoundException();
+        }
 
-        // 시드 기반 문제 순서 섞기
-        int seed = session.getSeed();
-        Collections.shuffle(allIds, new Random(seed));
+        if (startIndex >= totalQuestions) {
+            throw new RunAndLearnQuestionExhaustedException();
+        }
 
-        int endIndex = Math.min(startIndex + count, maxId.intValue());
-        List<Long> questionIds = allIds.subList(startIndex, endIndex);
+        int endIndex = Math.min(startIndex + count, totalQuestions);
+        List<Long> questionIds = sessionQuestionIds.subList(startIndex, endIndex);
 
         List<RunAndLearnQuestion> questions = getQuestionAndRestoreOrder(questionIds);
 
@@ -62,20 +63,8 @@ public class RunAndLearnQueryService {
                 .toList();
     }
 
-    // 문제의 최대 id를 가져오고 검증
-    private Long validateAndGetMaxId(int startIndex) {
-        Long maxId = runAndLearnQuestionRepository.findMaxId()
-                .orElseThrow(RunAndLearnQuestionNotFoundException::new);
-
-        if (startIndex >= maxId) {
-            throw new RunAndLearnQuestionExhaustedException();
-        }
-
-        return maxId;
-    }
-
     /**
-     * questionId 순서에 맞게 가져오기. findAllById는 순서를 보장하지 않기 때문에 Map을 사용해서 정렬
+     * questionId 순서에 맞게 가져오기. findAllById는 순서를 보장하지 않기 때문에 Map을 사용해서 순서 재배치
      */
     public List<RunAndLearnQuestion> getQuestionAndRestoreOrder(List<Long> questionIds) {
         List<RunAndLearnQuestion> questions = runAndLearnQuestionRepository.findAllById(

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/StartRunAndLearnSessionService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/StartRunAndLearnSessionService.java
@@ -1,5 +1,6 @@
 package com.gyu.engdu.domain.gamification.application;
 
+import com.gyu.engdu.domain.gamification.application.dto.response.StartRunAndLearnSessionResponse;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +14,13 @@ public class StartRunAndLearnSessionService {
     private final RunAndLearnQueryService runAndLearnQueryService;
 
     @Transactional
-    public void start(Long userId, Long sessionId, LocalDateTime startTime) {
+    public StartRunAndLearnSessionResponse start(Long userId, Long sessionId,
+            LocalDateTime startTime) {
         RunAndLearnSession session = runAndLearnQueryService.findExistingSession(sessionId);
 
         session.validateOwner(userId);
         session.start(startTime);
+
+        return StartRunAndLearnSessionResponse.of(startTime);
     }
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/cache/CaffeineCacheConfig.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/cache/CaffeineCacheConfig.java
@@ -1,0 +1,32 @@
+package com.gyu.engdu.domain.gamification.application.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CaffeineCacheConfig {
+
+    private static final long SHUFFLED_CACHE_TTL_MINUTES = 5;
+    private static final long ALL_IDS_CACHE_TTL_HOURS = 24;
+    private static final long MAXIMUM_CACHE_SIZE = 100;
+
+    @Bean
+    public Cache<Long, List<Long>> sessionCache() {
+        return Caffeine.newBuilder()
+                .maximumSize(MAXIMUM_CACHE_SIZE)
+                .expireAfterAccess(SHUFFLED_CACHE_TTL_MINUTES, TimeUnit.MINUTES)
+                .build();
+    }
+
+    @Bean
+    public Cache<String, List<Long>> allIdsCache() {
+        return Caffeine.newBuilder()
+                .maximumSize(1) // 전체 ID는 단일 키만 사용하므로 크기 1로 관리
+                .expireAfterWrite(ALL_IDS_CACHE_TTL_HOURS, TimeUnit.HOURS)
+                .build();
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/cache/CaffeineRunAndLearnCache.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/cache/CaffeineRunAndLearnCache.java
@@ -1,0 +1,46 @@
+package com.gyu.engdu.domain.gamification.application.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CaffeineRunAndLearnCache implements RunAndLearnCache {
+
+    private static final String ALL_IDS_KEY = "ALL_QUESTION_IDS";
+
+    // 세션별 셔플된 문제 ID 캐시
+    private final Cache<Long, List<Long>> sessionCache;
+
+    // 전체 문제 ID 캐시
+    private final Cache<String, List<Long>> allIdsCache;
+
+    @Override
+    public void saveSessionQuestionIds(Long sessionId, List<Long> questionIds) {
+        sessionCache.put(sessionId, questionIds);
+    }
+
+    @Override
+    public Optional<List<Long>> getSessionQuestionIds(Long sessionId) {
+        return Optional.ofNullable(sessionCache.getIfPresent(sessionId));
+    }
+
+    @Override
+    public void removeSessionQuestionIds(Long sessionId) {
+        sessionCache.invalidate(sessionId);
+    }
+
+    @Override
+    public void saveAllQuestionIds(List<Long> questionIds) {
+        allIdsCache.put(ALL_IDS_KEY, questionIds);
+    }
+
+    @Override
+    public Optional<List<Long>> getAllQuestionIds() {
+        return Optional.ofNullable(allIdsCache.getIfPresent(ALL_IDS_KEY));
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/cache/RunAndLearnCache.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/cache/RunAndLearnCache.java
@@ -1,0 +1,23 @@
+package com.gyu.engdu.domain.gamification.application.cache;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RunAndLearnCache {
+
+    // 특정 세션의 문제 리스트를 캐시에 저장
+    void saveSessionQuestionIds(Long sessionId, List<Long> questionIds);
+
+    // 특정 세션의 문제 리스트를 캐시에서 조회
+    Optional<List<Long>> getSessionQuestionIds(Long sessionId);
+
+    // 특정 세션의 캐시 삭제
+    void removeSessionQuestionIds(Long sessionId);
+
+    // 전체 문제 리스트를 캐시에 저장
+    void saveAllQuestionIds(List<Long> questionIds);
+
+    // 전체 문제 리스트를 캐시에서 조회
+    Optional<List<Long>> getAllQuestionIds();
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/cache/RunAndLearnCacheService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/cache/RunAndLearnCacheService.java
@@ -1,0 +1,61 @@
+package com.gyu.engdu.domain.gamification.application.cache;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestionRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RunAndLearnCacheService {
+
+    private final RunAndLearnCache runAndLearnCache;
+    private final RunAndLearnQuestionRepository runAndLearnQuestionRepository;
+
+    // 캐시에서 세션의 문제 ID 리스트를 조회하거나 생성 후 반환
+    public List<Long> getSessionQuestionIds(Long sessionId, int seed) {
+        log.info("세션 문제 캐시 조회 요청: sessionId={}", sessionId);
+        return runAndLearnCache.getSessionQuestionIds(sessionId)
+                .orElseGet(() -> createAndCacheShuffledQuestionIds(sessionId, seed));
+    }
+
+    // 전체 문제 ID를 조회한 뒤 시드에 맞게 섞어 세션 캐시에 저장하고 반환
+    private List<Long> createAndCacheShuffledQuestionIds(Long sessionId, int seed) {
+        List<Long> allIds = getAllQuestionIds();
+
+        // 세션의 시드 번호에 맞게 런앤런의 문제 순서를 섞음
+        List<Long> sessionQuestionIds = new ArrayList<>(allIds);
+        Collections.shuffle(sessionQuestionIds, new Random(seed));
+
+        log.info("새로운 세션 문제 캐시 등록: sessionId={}", sessionId);
+        runAndLearnCache.saveSessionQuestionIds(sessionId, sessionQuestionIds);
+
+        return sessionQuestionIds;
+    }
+
+    // 캐시에서 전체 문제 ID 리스트를 조회하거나 DB에서 조회 후 반환
+    public List<Long> getAllQuestionIds() {
+        log.info("전체 문제 캐시 조회 요청");
+        return runAndLearnCache.getAllQuestionIds()
+                .orElseGet(this::fetchAndCacheAllQuestionIds);
+    }
+
+    // DB에서 전체 문제 ID 목록을 조회하여 캐시에 저장한 후 반환
+    private List<Long> fetchAndCacheAllQuestionIds() {
+        List<Long> allIds = runAndLearnQuestionRepository.findAllIds();
+        log.info("전체 문제 캐시 등록");
+        runAndLearnCache.saveAllQuestionIds(allIds);
+        return allIds;
+    }
+
+    // 세션의 캐시 데이터를 삭제
+    public void removeSessionQuestionIds(Long sessionId) {
+        log.info("세션 문제 캐시 삭제: sessionId={}", sessionId);
+        runAndLearnCache.removeSessionQuestionIds(sessionId);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/request/EndRunAndLearnSessionRequest.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/request/EndRunAndLearnSessionRequest.java
@@ -1,0 +1,12 @@
+package com.gyu.engdu.domain.gamification.application.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record EndRunAndLearnSessionRequest(
+        @NotNull(message = "총 점수는 필수입니다.") Integer clientTotalScore,
+        @NotEmpty(message = "제출된 답변 리스트는 비어있을 수 없습니다.") List<SubmittedAnswer> submittedAnswers
+) {
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/request/SubmittedAnswer.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/request/SubmittedAnswer.java
@@ -1,0 +1,10 @@
+package com.gyu.engdu.domain.gamification.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SubmittedAnswer(
+        @NotNull(message = "문제 ID는 필수입니다.") Long questionId,
+        @NotNull(message = "제출 답안은 필수입니다.") Integer userAnswer
+) {
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/StartRunAndLearnSessionResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/StartRunAndLearnSessionResponse.java
@@ -1,0 +1,12 @@
+package com.gyu.engdu.domain.gamification.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StartRunAndLearnSessionResponse(
+        LocalDateTime startTime
+) {
+
+    public static StartRunAndLearnSessionResponse of(LocalDateTime startTime) {
+        return new StartRunAndLearnSessionResponse(startTime);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationService.java
@@ -1,0 +1,91 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import com.gyu.engdu.domain.gamification.application.dto.request.SubmittedAnswer;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnAllCorrectException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnInvalidEndException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnScoreMismatchException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSequenceMismatchException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnWrongAnswerBeforeEndException;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RunAndLearnEndValidationService {
+
+    private static final int SCORE_PER_QUESTION = 10;
+
+    /**
+     * 사용자가 세션에서 정해진 순서의 문제를 풀었는지 검증.
+     * 사용자가 푼 문제들이 올바른 답인지 검증. 단, 마지막 문제는 오답만 가능
+     * 사용자가 클라이언트에서 계산한 점수와 서버에서 계산한 점수가 일치하는지 검증
+     **/
+    public void validate(
+            RunAndLearnSession session,
+            Long maxQuestionId,
+            List<SubmittedAnswer> submittedAnswers,
+            List<RunAndLearnQuestion> expectedQuestions,
+            int clientTotalScore) {
+
+        validateQuestionSequence(submittedAnswers, expectedQuestions);
+
+        validateAnswers(submittedAnswers, expectedQuestions, maxQuestionId);
+
+        int correctCount = submittedAnswers.size() - 1;
+        validateTotalScore(clientTotalScore, correctCount);
+    }
+
+    // 사용자가 세션에서 정상적으로 섞은 순서대로 문제를 풀었는지 검증
+    private void validateQuestionSequence(List<SubmittedAnswer> submittedAnswers,
+            List<RunAndLearnQuestion> expectedQuestions) {
+
+        for (int i = 0; i < submittedAnswers.size(); i++) {
+            SubmittedAnswer submission = submittedAnswers.get(i);
+            Long expectedQuestionId = expectedQuestions.get(i).getId();
+
+            if (!expectedQuestionId.equals(submission.questionId())) {
+                throw new RunAndLearnSequenceMismatchException();
+            }
+        }
+    }
+
+    // 사용자가 푼 답안들이 올바른 답인지 검증. 단, 마지막 문제는 오답만 가능
+    private void validateAnswers(List<SubmittedAnswer> submittedAnswers,
+            List<RunAndLearnQuestion> expectedQuestions,
+            Long maxQuestionId) {
+        int submitCount = submittedAnswers.size();
+
+        for (int i = 0; i < submitCount - 1; i++) {
+            SubmittedAnswer submission = submittedAnswers.get(i);
+            RunAndLearnQuestion question = expectedQuestions.get(i);
+
+            boolean isCorrect = question.getAnswer().equals(submission.userAnswer());
+
+            if (!isCorrect) {
+                throw new RunAndLearnWrongAnswerBeforeEndException();
+            }
+        }
+
+        // 마지막 문제 검증
+        SubmittedAnswer lastSubmission = submittedAnswers.get(submitCount - 1);
+        RunAndLearnQuestion lastQuestion = expectedQuestions.get(submitCount - 1);
+        boolean isLastCorrect = lastQuestion.getAnswer().equals(lastSubmission.userAnswer());
+
+        // 마지막 문제가 맞다면 정상적인 게임 종료 방법이 아님
+        if (isLastCorrect) {
+            if (submitCount == maxQuestionId.intValue()) {
+                throw new RunAndLearnAllCorrectException();
+            }
+            throw new RunAndLearnInvalidEndException();
+        }
+    }
+
+    // 클라이언트와 서버의 점수가 일치하는지 검증
+    private void validateTotalScore(int clientTotalScore, int correctCount) {
+        long serverScore = (long) correctCount * SCORE_PER_QUESTION;
+
+        if (clientTotalScore != serverScore) {
+            throw new RunAndLearnScoreMismatchException();
+        }
+    }
+
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationService.java
@@ -21,14 +21,14 @@ public class RunAndLearnEndValidationService {
      **/
     public void validate(
             RunAndLearnSession session,
-            Long maxQuestionId,
+            int totalQuestions,
             List<SubmittedAnswer> submittedAnswers,
             List<RunAndLearnQuestion> expectedQuestions,
             int clientTotalScore) {
 
         validateQuestionSequence(submittedAnswers, expectedQuestions);
 
-        validateAnswers(submittedAnswers, expectedQuestions, maxQuestionId);
+        validateAnswers(submittedAnswers, expectedQuestions, totalQuestions);
 
         int correctCount = submittedAnswers.size() - 1;
         validateTotalScore(clientTotalScore, correctCount);
@@ -51,7 +51,7 @@ public class RunAndLearnEndValidationService {
     // 사용자가 푼 답안들이 올바른 답인지 검증. 단, 마지막 문제는 오답만 가능
     private void validateAnswers(List<SubmittedAnswer> submittedAnswers,
             List<RunAndLearnQuestion> expectedQuestions,
-            Long maxQuestionId) {
+            int totalQuestions) {
         int submitCount = submittedAnswers.size();
 
         for (int i = 0; i < submitCount - 1; i++) {
@@ -72,7 +72,7 @@ public class RunAndLearnEndValidationService {
 
         // 마지막 문제가 맞다면 정상적인 게임 종료 방법이 아님
         if (isLastCorrect) {
-            if (submitCount == maxQuestionId.intValue()) {
+            if (submitCount == totalQuestions) {
                 throw new RunAndLearnAllCorrectException();
             }
             throw new RunAndLearnInvalidEndException();

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestionRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnQuestionRepository.java
@@ -1,5 +1,6 @@
 package com.gyu.engdu.domain.gamification.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,5 +9,8 @@ public interface RunAndLearnQuestionRepository extends JpaRepository<RunAndLearn
 
     @Query("SELECT MAX(q.id) FROM RunAndLearnQuestion q")
     Optional<Long> findMaxId();
+
+    @Query("SELECT q.id FROM RunAndLearnQuestion q ORDER BY q.id ASC")
+    List<Long> findAllIds();
 
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSession.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSession.java
@@ -1,12 +1,16 @@
 package com.gyu.engdu.domain.gamification.domain;
 
 import com.gyu.engdu.domain.BaseEntity;
+import com.gyu.engdu.domain.gamification.domain.enums.RunAndLearnSessionStatus;
+import com.gyu.engdu.domain.gamification.exception.InvalidRunAndLearnStatusException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionAlreadyStartedException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionForbiddenAccessException;
 import com.gyu.engdu.domain.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -42,11 +46,16 @@ public class RunAndLearnSession extends BaseEntity {
 
     private LocalDateTime endedAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RunAndLearnSessionStatus status;
+
     @Builder
     private RunAndLearnSession(User user, int seed, int score) {
         this.user = user;
         this.seed = seed;
         this.score = score;
+        this.status = RunAndLearnSessionStatus.INIT;
     }
 
     public static RunAndLearnSession of(User user, int seed) {
@@ -59,15 +68,27 @@ public class RunAndLearnSession extends BaseEntity {
 
     public void validateOwner(Long userId) {
         if (!this.user.getId().equals(userId)) {
-            throw new RunAndLearnSessionForbiddenAccessException(userId, this.id, this.user.getId());
+            throw new RunAndLearnSessionForbiddenAccessException(userId, this.id,
+                    this.user.getId());
         }
     }
 
     public void start(LocalDateTime startTime) {
-        if (this.startedAt != null) {
+        if (this.status != RunAndLearnSessionStatus.INIT) {
             throw new RunAndLearnSessionAlreadyStartedException(this.id);
         }
         this.startedAt = startTime;
+        this.status = RunAndLearnSessionStatus.PROGRESS;
+    }
+
+    public void end(int finalScore, LocalDateTime endTime) {
+        if (this.status == RunAndLearnSessionStatus.ENDED
+                || this.status == RunAndLearnSessionStatus.INIT) {
+            throw new InvalidRunAndLearnStatusException(this.status);
+        }
+        this.score = finalScore;
+        this.endedAt = endTime;
+        this.status = RunAndLearnSessionStatus.ENDED;
     }
 
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/enums/RunAndLearnSessionStatus.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/enums/RunAndLearnSessionStatus.java
@@ -1,0 +1,7 @@
+package com.gyu.engdu.domain.gamification.domain.enums;
+
+public enum RunAndLearnSessionStatus {
+    INIT,
+    PROGRESS,
+    ENDED
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnPlayException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnPlayException.java
@@ -1,9 +1,9 @@
 package com.gyu.engdu.domain.gamification.exception;
 
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class InvalidRunAndLearnPlayException extends CustomException {
+public class InvalidRunAndLearnPlayException extends ValidationException {
 
     public InvalidRunAndLearnPlayException(String reason) {
         super(ErrorCode.RUN_AND_LEARN_INVALID_PLAY, "유효하지 않은 플레이 감지: " + reason);

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnPlayException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnPlayException.java
@@ -1,0 +1,11 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class InvalidRunAndLearnPlayException extends CustomException {
+
+    public InvalidRunAndLearnPlayException(String reason) {
+        super(ErrorCode.RUN_AND_LEARN_INVALID_PLAY, "유효하지 않은 플레이 감지: " + reason);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnStatusException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnStatusException.java
@@ -1,10 +1,10 @@
 package com.gyu.engdu.domain.gamification.exception;
 
 import com.gyu.engdu.domain.gamification.domain.enums.RunAndLearnSessionStatus;
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class InvalidRunAndLearnStatusException extends CustomException {
+public class InvalidRunAndLearnStatusException extends ValidationException {
 
     public InvalidRunAndLearnStatusException(RunAndLearnSessionStatus status) {
         super(ErrorCode.RUN_AND_LEARN_INVALID_PLAY, "세션의 상태가 올바르지 않습니다. 현재 상태: " + status);

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnStatusException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnStatusException.java
@@ -1,0 +1,12 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.domain.gamification.domain.enums.RunAndLearnSessionStatus;
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class InvalidRunAndLearnStatusException extends CustomException {
+
+    public InvalidRunAndLearnStatusException(RunAndLearnSessionStatus status) {
+        super(ErrorCode.RUN_AND_LEARN_INVALID_PLAY, "세션의 상태가 올바르지 않습니다. 현재 상태: " + status);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnAllCorrectException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnAllCorrectException.java
@@ -1,0 +1,11 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class RunAndLearnAllCorrectException extends CustomException {
+
+    public RunAndLearnAllCorrectException() {
+        super(ErrorCode.RUN_AND_LEARN_ALL_CORRECT, "모든 문제를 맞추었습니다. 정상적인 종료가 아닙니다.");
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnAllCorrectException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnAllCorrectException.java
@@ -1,9 +1,9 @@
 package com.gyu.engdu.domain.gamification.exception;
 
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class RunAndLearnAllCorrectException extends CustomException {
+public class RunAndLearnAllCorrectException extends ValidationException {
 
     public RunAndLearnAllCorrectException() {
         super(ErrorCode.RUN_AND_LEARN_ALL_CORRECT, "모든 문제를 맞추었습니다. 정상적인 종료가 아닙니다.");

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnInvalidEndException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnInvalidEndException.java
@@ -1,0 +1,11 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class RunAndLearnInvalidEndException extends CustomException {
+
+    public RunAndLearnInvalidEndException() {
+        super(ErrorCode.RUN_AND_LEARN_INVALID_END);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnInvalidEndException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnInvalidEndException.java
@@ -1,9 +1,9 @@
 package com.gyu.engdu.domain.gamification.exception;
 
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class RunAndLearnInvalidEndException extends CustomException {
+public class RunAndLearnInvalidEndException extends ValidationException {
 
     public RunAndLearnInvalidEndException() {
         super(ErrorCode.RUN_AND_LEARN_INVALID_END);

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnScoreMismatchException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnScoreMismatchException.java
@@ -1,0 +1,11 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class RunAndLearnScoreMismatchException extends CustomException {
+
+    public RunAndLearnScoreMismatchException() {
+        super(ErrorCode.RUN_AND_LEARN_SCORE_MISMATCH);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnScoreMismatchException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnScoreMismatchException.java
@@ -1,9 +1,9 @@
 package com.gyu.engdu.domain.gamification.exception;
 
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class RunAndLearnScoreMismatchException extends CustomException {
+public class RunAndLearnScoreMismatchException extends ValidationException {
 
     public RunAndLearnScoreMismatchException() {
         super(ErrorCode.RUN_AND_LEARN_SCORE_MISMATCH);

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSequenceMismatchException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSequenceMismatchException.java
@@ -1,9 +1,9 @@
 package com.gyu.engdu.domain.gamification.exception;
 
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class RunAndLearnSequenceMismatchException extends CustomException {
+public class RunAndLearnSequenceMismatchException extends ValidationException {
 
     public RunAndLearnSequenceMismatchException() {
         super(ErrorCode.RUN_AND_LEARN_SEQUENCE_MISMATCH);

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSequenceMismatchException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnSequenceMismatchException.java
@@ -1,0 +1,11 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class RunAndLearnSequenceMismatchException extends CustomException {
+
+    public RunAndLearnSequenceMismatchException() {
+        super(ErrorCode.RUN_AND_LEARN_SEQUENCE_MISMATCH);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnWrongAnswerBeforeEndException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnWrongAnswerBeforeEndException.java
@@ -1,0 +1,11 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ErrorCode;
+
+public class RunAndLearnWrongAnswerBeforeEndException extends CustomException {
+
+    public RunAndLearnWrongAnswerBeforeEndException() {
+        super(ErrorCode.RUN_AND_LEARN_WRONG_ANSWER_BEFORE_END);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnWrongAnswerBeforeEndException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/RunAndLearnWrongAnswerBeforeEndException.java
@@ -1,9 +1,9 @@
 package com.gyu.engdu.domain.gamification.exception;
 
-import com.gyu.engdu.global.exception.CustomException;
+import com.gyu.engdu.global.exception.ValidationException;
 import com.gyu.engdu.global.exception.ErrorCode;
 
-public class RunAndLearnWrongAnswerBeforeEndException extends CustomException {
+public class RunAndLearnWrongAnswerBeforeEndException extends ValidationException {
 
     public RunAndLearnWrongAnswerBeforeEndException() {
         super(ErrorCode.RUN_AND_LEARN_WRONG_ANSWER_BEFORE_END);

--- a/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
@@ -1,10 +1,13 @@
 package com.gyu.engdu.domain.gamification.presentation;
 
 import com.gyu.engdu.domain.gamification.application.CreateRunAndLearnSessionService;
+import com.gyu.engdu.domain.gamification.application.EndRunAndLearnSessionService;
 import com.gyu.engdu.domain.gamification.application.RunAndLearnQueryService;
 import com.gyu.engdu.domain.gamification.application.StartRunAndLearnSessionService;
+import com.gyu.engdu.domain.gamification.application.dto.request.EndRunAndLearnSessionRequest;
 import com.gyu.engdu.domain.gamification.application.dto.response.CreateRunAndLearnSessionResponse;
 import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnQuestionResponse;
+import com.gyu.engdu.domain.gamification.application.dto.response.StartRunAndLearnSessionResponse;
 import com.gyu.engdu.domain.gamification.presentation.dto.request.RunAndLearnQuestionRequest;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
@@ -16,6 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,6 +31,7 @@ public class RunAndLearnController {
     private final CreateRunAndLearnSessionService createRunAndLearnSessionService;
     private final StartRunAndLearnSessionService startRunAndLearnSessionService;
     private final RunAndLearnQueryService runAndLearnQueryService;
+    private final EndRunAndLearnSessionService endRunAndLearnSessionService;
 
     @PostMapping
     public ResponseEntity<CreateRunAndLearnSessionResponse> createSession(
@@ -38,12 +43,13 @@ public class RunAndLearnController {
     }
 
     @PostMapping("/{sessionId}/start")
-    public ResponseEntity<Void> startSession(
+    public ResponseEntity<StartRunAndLearnSessionResponse> startSession(
             @PathVariable("sessionId") Long sessionId,
             @AuthenticationPrincipal(expression = "userId") Long userId) {
-        startRunAndLearnSessionService.start(userId, sessionId, LocalDateTime.now());
+        StartRunAndLearnSessionResponse response = startRunAndLearnSessionService.start(userId,
+                sessionId, LocalDateTime.now());
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{sessionId}/question")
@@ -52,13 +58,19 @@ public class RunAndLearnController {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @Valid RunAndLearnQuestionRequest request) {
 
-        List<RunAndLearnQuestionResponse> response = runAndLearnQueryService.getQuestions(
-                userId,
-                sessionId,
-                request.startIndex(),
-                request.count()
-        );
+        List<RunAndLearnQuestionResponse> response = runAndLearnQueryService.getQuestions(userId,
+                sessionId, request.startIndex(), request.count());
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{sessionId}/end")
+    public ResponseEntity<Void> endSession(@PathVariable("sessionId") Long sessionId,
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Valid @RequestBody EndRunAndLearnSessionRequest request) {
+
+        endRunAndLearnSessionService.endSession(userId, sessionId, request, LocalDateTime.now());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
+++ b/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
@@ -42,6 +42,12 @@ public enum ErrorCode {
   RUN_AND_LEARN_ALREADY_STARTED("GAMIFICATION-004", "이미 시작된 스피드 퀴즈 세션입니다."),
   RUN_AND_LEARN_QUESTION_NOT_FOUND("GAMIFICATION-005", "런앤런 문제가 존재하지 않습니다."),
   RUN_AND_LEARN_QUESTION_EXHAUSTED("GAMIFICATION-006", "더 이상 런앤런 문제가 남아있지 않습니다."),
+  RUN_AND_LEARN_INVALID_PLAY("GAMIFICATION-007", "비정상적인 런앤런 플레이가 감지되었습니다."),
+  RUN_AND_LEARN_ALL_CORRECT("GAMIFICATION-008", "모든 런앤런 문제를 맞추었습니다."),
+  RUN_AND_LEARN_SEQUENCE_MISMATCH("GAMIFICATION-009", "문제의 순서가 올바르지 않습니다."),
+  RUN_AND_LEARN_WRONG_ANSWER_BEFORE_END("GAMIFICATION-010", "오답이 발생했지만 게임이 종료되지 않았습니다."),
+  RUN_AND_LEARN_INVALID_END("GAMIFICATION-011", "마지막 문제를 맞추었으나 게임이 비정상적으로 종료되었습니다."),
+  RUN_AND_LEARN_SCORE_MISMATCH("GAMIFICATION-012", "클라이언트 점수와 서버에서 계산된 점수가 일치하지 않습니다."),
 
   // Spring Standard Errors
   INVALID_INPUT_VALUE("COMMON-001", "잘못된 입력값입니다."),

--- a/src/main/java/com/gyu/engdu/global/exception/ValidationException.java
+++ b/src/main/java/com/gyu/engdu/global/exception/ValidationException.java
@@ -2,6 +2,10 @@ package com.gyu.engdu.global.exception;
 
 public abstract class ValidationException extends CustomException {
 
+    protected ValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
     protected ValidationException(ErrorCode errorCode, String detailMessage) {
         super(errorCode, detailMessage);
     }

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationServiceTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class RunAndLearnEndValidationServiceTest {
 
-    private final Long MAX_QUESTION_ID = 5L;
+    private final int TOTAL_QUESTIONS = 5;
     private RunAndLearnEndValidationService validationService;
     private RunAndLearnSession session;
 
@@ -51,7 +51,7 @@ class RunAndLearnEndValidationServiceTest {
 
         // when & then
         assertThatCode(
-                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                () -> validationService.validate(session, TOTAL_QUESTIONS, submissions, questions,
                         clientTotalScore))
                 .doesNotThrowAnyException();
     }
@@ -70,7 +70,7 @@ class RunAndLearnEndValidationServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                () -> validationService.validate(session, TOTAL_QUESTIONS, submissions, questions,
                         clientTotalScore))
                 .isInstanceOf(RunAndLearnSequenceMismatchException.class);
     }
@@ -91,7 +91,7 @@ class RunAndLearnEndValidationServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                () -> validationService.validate(session, TOTAL_QUESTIONS, submissions, questions,
                         clientTotalScore))
                 .isInstanceOf(RunAndLearnWrongAnswerBeforeEndException.class);
     }
@@ -103,7 +103,7 @@ class RunAndLearnEndValidationServiceTest {
         List<RunAndLearnQuestion> questions = new ArrayList<>();
         List<SubmittedAnswer> submissions = new ArrayList<>();
 
-        for (long i = 1; i <= MAX_QUESTION_ID; i++) {
+        for (long i = 1; i <= TOTAL_QUESTIONS; i++) {
             questions.add(createRunAndLearnQuestion(i, (int) i));
             submissions.add(new SubmittedAnswer(i, (int) i));
         }
@@ -112,7 +112,7 @@ class RunAndLearnEndValidationServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                () -> validationService.validate(session, TOTAL_QUESTIONS, submissions, questions,
                         allCorrectScore))
                 .isInstanceOf(RunAndLearnAllCorrectException.class);
     }
@@ -135,7 +135,7 @@ class RunAndLearnEndValidationServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                () -> validationService.validate(session, TOTAL_QUESTIONS, submissions, questions,
                         clientTotalScore))
                 .isInstanceOf(RunAndLearnInvalidEndException.class);
     }
@@ -156,7 +156,7 @@ class RunAndLearnEndValidationServiceTest {
 
         // when & then
         assertThatThrownBy(
-                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                () -> validationService.validate(session, TOTAL_QUESTIONS, submissions, questions,
                         wrongClientScore))
                 .isInstanceOf(RunAndLearnScoreMismatchException.class);
     }

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationServiceTest.java
@@ -1,0 +1,172 @@
+spackage com.gyu.engdu.domain.gamification.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gyu.engdu.domain.gamification.application.dto.request.SubmittedAnswer;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnAllCorrectException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnInvalidEndException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnScoreMismatchException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnSequenceMismatchException;
+import com.gyu.engdu.domain.gamification.exception.RunAndLearnWrongAnswerBeforeEndException;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RunAndLearnEndValidationServiceTest {
+
+    private final Long MAX_QUESTION_ID = 5L;
+    private RunAndLearnEndValidationService validationService;
+    private RunAndLearnSession session;
+
+    @BeforeEach
+    void setUp() {
+        validationService = new RunAndLearnEndValidationService();
+        User user = User.builder().email("test@test.com").role(Role.ROLE_USER).sub("sub123")
+                .name("user").build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        session = RunAndLearnSession.of(user, 12345);
+    }
+
+    @Test
+    @DisplayName("모든 검증을 통과하면 예외가 발생하지 않는다.")
+    void validateSuccess() {
+        // given
+        List<RunAndLearnQuestion> questions = List.of(
+                createRunAndLearnQuestion(1L, 1),
+                createRunAndLearnQuestion(2L, 2),
+                createRunAndLearnQuestion(3L, 3));
+
+        List<SubmittedAnswer> submissions = List.of(
+                new SubmittedAnswer(1L, 1),
+                new SubmittedAnswer(2L, 2),
+                new SubmittedAnswer(3L, 999));
+
+        int clientTotalScore = 20;
+
+        // when & then
+        assertThatCode(
+                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                        clientTotalScore))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("제출된 답변의 문제 ID 순서가 예상과 다르면 예외가 발생한다")
+    void validateWrongSequence() {
+        // given
+        List<RunAndLearnQuestion> questions = List.of(
+                createRunAndLearnQuestion(1L, 1));
+
+        List<SubmittedAnswer> submissions = List.of(
+                new SubmittedAnswer(2L, 1));
+
+        int clientTotalScore = 0;
+
+        // when & then
+        assertThatThrownBy(
+                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                        clientTotalScore))
+                .isInstanceOf(RunAndLearnSequenceMismatchException.class);
+    }
+
+    @Test
+    @DisplayName("마지막 문제가 아닌데 오답이 있으면 예외가 발생한다")
+    void validateWrongAnswerBeforeEnd() {
+        // given
+        List<RunAndLearnQuestion> questions = List.of(
+                createRunAndLearnQuestion(1L, 1),
+                createRunAndLearnQuestion(2L, 2));
+
+        List<SubmittedAnswer> submissions = List.of(
+                new SubmittedAnswer(1L, 999),
+                new SubmittedAnswer(2L, 999));
+
+        int clientTotalScore = 0;
+
+        // when & then
+        assertThatThrownBy(
+                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                        clientTotalScore))
+                .isInstanceOf(RunAndLearnWrongAnswerBeforeEndException.class);
+    }
+
+    @Test
+    @DisplayName("모든 문제를 맞추면 예외가 발생한다")
+    void validateAllCorrect() {
+        // given
+        List<RunAndLearnQuestion> questions = new ArrayList<>();
+        List<SubmittedAnswer> submissions = new ArrayList<>();
+
+        for (long i = 1; i <= MAX_QUESTION_ID; i++) {
+            questions.add(createRunAndLearnQuestion(i, (int) i));
+            submissions.add(new SubmittedAnswer(i, (int) i));
+        }
+
+        int allCorrectScore = 50;
+
+        // when & then
+        assertThatThrownBy(
+                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                        allCorrectScore))
+                .isInstanceOf(RunAndLearnAllCorrectException.class);
+    }
+
+    @Test
+    @DisplayName("마지막 문제를 맞추고 끝나면 예외가 발생한다")
+    void validateCorrectLastAnswerButNotAll() {
+        // given
+        List<RunAndLearnQuestion> questions = List.of(
+                createRunAndLearnQuestion(1L, 1),
+                createRunAndLearnQuestion(2L, 2),
+                createRunAndLearnQuestion(3L, 3));
+
+        List<SubmittedAnswer> submissions = List.of(
+                new SubmittedAnswer(1L, 1),
+                new SubmittedAnswer(2L, 2),
+                new SubmittedAnswer(3L, 3));
+
+        int clientTotalScore = 30;
+
+        // when & then
+        assertThatThrownBy(
+                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                        clientTotalScore))
+                .isInstanceOf(RunAndLearnInvalidEndException.class);
+    }
+
+    @Test
+    @DisplayName("클라이언트 점수가 계산된 점수와 다르면 예외가 발생한다")
+    void validateWrongScore() {
+        // given
+        List<RunAndLearnQuestion> questions = List.of(
+                createRunAndLearnQuestion(1L, 1),
+                createRunAndLearnQuestion(2L, 2));
+
+        List<SubmittedAnswer> submissions = List.of(
+                new SubmittedAnswer(1L, 1),
+                new SubmittedAnswer(2L, 999));
+
+        int wrongClientScore = 20;
+
+        // when & then
+        assertThatThrownBy(
+                () -> validationService.validate(session, MAX_QUESTION_ID, submissions, questions,
+                        wrongClientScore))
+                .isInstanceOf(RunAndLearnScoreMismatchException.class);
+    }
+
+    private RunAndLearnQuestion createRunAndLearnQuestion(Long id, int answer) {
+        RunAndLearnQuestion question = RunAndLearnQuestion.builder()
+                .question("Q" + id)
+                .answer(answer)
+                .build();
+        ReflectionTestUtils.setField(question, "id", id);
+        return question;
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnEndValidationServiceTest.java
@@ -1,4 +1,4 @@
-spackage com.gyu.engdu.domain.gamification.domain;
+package com.gyu.engdu.domain.gamification.domain;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionTest.java
@@ -4,10 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.gyu.engdu.domain.gamification.domain.enums.RunAndLearnSessionStatus;
+import com.gyu.engdu.domain.gamification.exception.InvalidRunAndLearnStatusException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionAlreadyStartedException;
 import com.gyu.engdu.domain.gamification.exception.RunAndLearnSessionForbiddenAccessException;
 import com.gyu.engdu.domain.user.domain.Role;
 import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.global.exception.ErrorCode;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +46,8 @@ class RunAndLearnSessionTest {
 
         // when & then
         assertThatThrownBy(() -> session.validateOwner(otherUserId))
-                .isInstanceOf(RunAndLearnSessionForbiddenAccessException.class);
+                .isInstanceOf(RunAndLearnSessionForbiddenAccessException.class)
+                .hasMessage(ErrorCode.RUN_AND_LEARN_FORBIDDEN_ACCESS.getMessage());
     }
 
     @Test
@@ -60,6 +64,8 @@ class RunAndLearnSessionTest {
 
         // then
         assertThat(session.getStartedAt()).isEqualTo(startTime);
+        assertThat(session.getStatus())
+                .isEqualTo(RunAndLearnSessionStatus.PROGRESS);
     }
 
     @Test
@@ -80,7 +86,7 @@ class RunAndLearnSessionTest {
     }
 
     @Test
-    @DisplayName("세션 생성 시 score의 초기값은 0이다.")
+    @DisplayName("런앤런 세션 생성 시 score의 초기값은 0이고 상태는 INIT이다.")
     void init() {
         // given
         User user = createUser(1L);
@@ -91,6 +97,56 @@ class RunAndLearnSessionTest {
 
         // then
         assertThat(session.getScore()).isZero();
+        assertThat(session.getStatus()).isEqualTo(RunAndLearnSessionStatus.INIT);
+    }
+
+    @Test
+    @DisplayName("진행 중인 런앤런 세션을 종료하면 상태가 ENDED로 변경되고 점수와 종료 시간이 저장된다.")
+    void end1() {
+        // given
+        User user = createUser(1L);
+        RunAndLearnSession session = RunAndLearnSession.of(user, 12345);
+        session.start(LocalDateTime.now());
+        LocalDateTime endTime = LocalDateTime.now().plusMinutes(5);
+        int score = 50;
+
+        // when
+        session.end(score, endTime);
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(RunAndLearnSessionStatus.ENDED);
+        assertThat(session.getScore()).isEqualTo(score);
+        assertThat(session.getEndedAt()).isEqualTo(endTime);
+    }
+
+    @Test
+    @DisplayName("초기화 상태의 런앤런 세션을 종료하면 예외가 발생한다.")
+    void endFromInit() {
+        // given
+        User user = createUser(1L);
+        RunAndLearnSession session = RunAndLearnSession.of(user, 12345);
+        int score = 50;
+        LocalDateTime endTime = LocalDateTime.now();
+
+        // when & then
+        assertThatThrownBy(() -> session.end(score, endTime))
+                .isInstanceOf(InvalidRunAndLearnStatusException.class)
+                .hasMessage(ErrorCode.RUN_AND_LEARN_INVALID_PLAY.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 종료된 런앤런 세션을 다시 종료하면 예외가 발생한다.")
+    void endFromEnded() {
+        // given
+        User user = createUser(1L);
+        RunAndLearnSession session = RunAndLearnSession.of(user, 12345);
+        session.start(LocalDateTime.now());
+        session.end(50, LocalDateTime.now());
+
+        // when & then
+        assertThatThrownBy(() -> session.end(60, LocalDateTime.now()))
+                .isInstanceOf(InvalidRunAndLearnStatusException.class)
+                .hasMessage(ErrorCode.RUN_AND_LEARN_INVALID_PLAY.getMessage());
     }
 
     private User createUser(Long id) {


### PR DESCRIPTION
## 연관된 이슈

- closed #133

## 작업 내용

### 개요

런앤런 게임 세션 종료 시 점수 조작 및 비정상 플레이를 방지하기 위해 클라이언트 제출 데이터에 대한 서버 사이드 검증 로직을 구현하고 종료 API를 추가하였습니다.

### 변경 사항

- **런앤런 종료 API 및 요청/응답 DTO 추가**:
  - RunAndLearnController에 종료 API 구현
  - EndRunAndLearnSessionRequest, SubmittedAnswer, StartRunAndLearnSessionResponse 추가
- **세션 종료 처리 로직 개발**:
  - EndRunAndLearnSessionService 구현
  - RunAndLearnEndValidationService를 통한 다각도 플레이 검증 로직 개발
    - 난수 시드 기반 문제 순서 검증 (실패 시 RunAndLearnSequenceMismatchException 발생)
    - 마지막 직전 문제까지 정답 처리 여부 검증 (실패 시 RunAndLearnWrongAnswerBeforeEndException 발생)
    - 마지막 문제의 오답 여부 검증 및 완주 여부 체크 (실패 시 각각 RunAndLearnInvalidEndException, RunAndLearnAllCorrectException 발생)
    - 최종 점수 교차 검증 (실패 시 RunAndLearnScoreMismatchException 발생)
- **세션 상태(Status) 관리 도입**:
  - RunAndLearnSessionStatus (INIT, PROGRESS, ENDED) 추가 및 상태 전이에 따른 비정상 종료 처리 예외(InvalidRunAndLearnStatusException) 구현
- **신규 에러 코드 정의**:
  - ErrorCode에 게임 종료 검증 실패와 관련된 에러 코드 추가
- **단위 및 통합 테스트 구현**:
  - RunAndLearnEndValidationServiceTest, RunAndLearnSessionTest 추가를 통해 다양한 예외 케이스 및 검증 로직을 통과하는지 검증 완료

### 스크린샷 (선택)


## 리뷰 요구사항(선택)



### 주요 고민 및 해결 과정

- 문제점: JPA Repository의 findAllById 호출 시 반환되는 질문 목록의 순서가 데이터베이스 조회 결과에 따라 임의로 정렬되어, 난수 시드로 생성된 올바른 문제 sequence 순서와 일치하지 않아 오답/순서 검증이 실패하는 문제가 있었습니다.
- 해결 과정: RunAndLearnQueryService 내에 getQuestionAndRestoreOrder 메서드를 작성하여 Map을 통해 전달된 ID 리스트의 원래 정렬 순서대로 질문 객체 목록을 다시 배치하여 반환하도록 함으로써 순서 불일치 문제를 해결했습니다.
