### PR TITLE
[FEAT] 런앤런 리더보드 엔티티 설계 

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -134,6 +134,19 @@ CREATE TABLE `run_and_learn_question` (
     `explanation` VARCHAR(255) NULL
 ) ENGINE=InnoDB;
 
+-- RunAndLearnRanking Table
+CREATE TABLE `run_and_learn_ranking` (
+    `run_and_learn_ranking_id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `user_id` BIGINT NOT NULL,
+    `ranking_type` VARCHAR(255) NOT NULL,
+    `season` INT NOT NULL,
+    `best_score` INT NOT NULL,
+    `achieved_at` DATETIME(6) NOT NULL,
+    `created_at` DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `modified_at` DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    CONSTRAINT `unique_user_ranking_season` UNIQUE (`user_id`, `ranking_type`, `season`)
+) ENGINE=InnoDB;
+
 -- **************************************** TABLE END****************************************
 
 -- **************************************** INDEX START ****************************************
@@ -146,4 +159,5 @@ CREATE INDEX idx_question_part_id ON `question` (`part_id`);
 CREATE INDEX idx_choice_question_id ON `choice` (`question_id`);
 CREATE INDEX idx_message_status ON `message` (`status`);
 CREATE INDEX idx_run_and_learn_session_user_id ON `run_and_learn_session` (`user_id`);
+CREATE INDEX idx_run_and_learn_ranking_lookup ON `run_and_learn_ranking` (`ranking_type`, `season`, `best_score` DESC, `achieved_at` ASC);
 -- **************************************** INDEX END ****************************************

--- a/src/main/java/com/gyu/engdu/domain/engdu/presentation/dto/response/EngduSummaryResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/presentation/dto/response/EngduSummaryResponse.java
@@ -8,6 +8,7 @@ public record EngduSummaryResponse(
     String title,
     String topic,
     Integer solvedCount,
+    Integer totalCount,
     Boolean isAllSolved,
     LocalDateTime createdAt) {
 
@@ -17,6 +18,7 @@ public record EngduSummaryResponse(
         engdu.getTitle(),
         engdu.getTopic(),
         engdu.getSolvedCount(),
+        4,
         engdu.isAllSolved(),
         engdu.getCreatedAt());
   }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRanking.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRanking.java
@@ -1,0 +1,69 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import com.gyu.engdu.domain.BaseEntity;
+import com.gyu.engdu.domain.gamification.domain.enums.RankingType;
+import com.gyu.engdu.domain.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "run_and_learn_ranking", uniqueConstraints = {
+        @UniqueConstraint(name = "unique_user_ranking_season", columnNames = {"user_id", "ranking_type", "season"})
+})
+public class RunAndLearnRanking extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "run_and_learn_ranking_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ranking_type", nullable = false)
+    private RankingType rankingType;
+
+    @Column(nullable = false)
+    private int season;
+
+    @Column(nullable = false)
+    private int bestScore;
+
+    @Column(nullable = false)
+    private LocalDateTime achievedAt;
+
+    @Builder
+    private RunAndLearnRanking(User user, RankingType rankingType, int season, int bestScore, LocalDateTime achievedAt) {
+        this.user = user;
+        this.rankingType = rankingType;
+        this.season = season;
+        this.bestScore = bestScore;
+        this.achievedAt = achievedAt;
+    }
+
+    public void updateScoreIfHigher(int newScore, LocalDateTime achievedAt) {
+        if (newScore > this.bestScore) {
+            this.bestScore = newScore;
+            this.achievedAt = achievedAt;
+        }
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/enums/RankingType.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/enums/RankingType.java
@@ -1,0 +1,6 @@
+package com.gyu.engdu.domain.gamification.domain.enums;
+
+public enum RankingType {
+    WEEKLY,
+    ALL_TIME
+}


### PR DESCRIPTION
## 연관된 이슈

- closed #140 

## 작업 내용

### 개요

런앤런(Run and Learn) 서비스의 리더보드(랭킹) 시스템 구현을 위한 도메인 모델(엔티티, Enum) 및 DDL을 설계했습니다.

### 변경 사항

#### 1. 런앤런 랭킹 도메인 모델 설계 및 최고 점수 갱신 로직 구현 (`RunAndLearnRanking.java`, `RankingType.java`)
- 랭킹 데이터(유저, 시즌, 최고 점수, 달성 시점 등)를 영속화하기 위한 `RunAndLearnRanking` 엔티티를 추가했습니다.
- 새롭게 획득한 점수가 기존 최고 점수보다 높을 때만 점수와 달성 시점을 업데이트하도록 엔티티 내부에 비즈니스 로직을 추가했습니다.
- 랭킹 종류를 구분하기 위해 `RankingType` (`WEEKLY`, `ALL_TIME`) 이넘을 추가했습니다.

#### 2. 리더보드 테이블 설계 및 데이터베이스 최적화
- 런앤런 랭킹 테이블(`run_and_learn_ranking`) 정의를 추가하고 유저별 시즌당 단 하나의 랭킹만 존재하도록 유니크 제약 조건을 생성했습니다.
- 리더보드 조회 시 효율적인 정렬 및 조회를 위해 복합 인덱스(`idx_run_and_learn_ranking_lookup` -> `ranking_type`, `season`, `best_score` 내림차순, `achieved_at` 오름차순)를 설계하여 리더보드 조회 쿼리 성능을 최적화했습니다.


