### PR TITLE
feat: 런앤런 세션 종료 시 랭킹 업데이트 연동 및 랭킹 결과 반환 API 구현

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/gamification/application/EndRunAndLearnSessionService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/EndRunAndLearnSessionService.java
@@ -2,6 +2,8 @@ package com.gyu.engdu.domain.gamification.application;
 
 import com.gyu.engdu.domain.gamification.application.cache.RunAndLearnCacheService;
 import com.gyu.engdu.domain.gamification.application.dto.request.EndRunAndLearnSessionRequest;
+import com.gyu.engdu.domain.gamification.application.dto.response.EndRunAndLearnSessionResponse;
+import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnRankingResult;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnEndValidationService;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnQuestion;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
@@ -22,8 +24,9 @@ public class EndRunAndLearnSessionService {
     private final RunAndLearnQueryService runAndLearnQueryService;
     private final RunAndLearnCacheService runAndLearnCacheService;
     private final RunAndLearnEndValidationService runAndLearnEndValidationService;
+    private final UpdateRunAndLearnRankingService updateRunAndLearnRankingService;
 
-    public void endSession(Long userId, Long sessionId, EndRunAndLearnSessionRequest request,
+    public EndRunAndLearnSessionResponse endSession(Long userId, Long sessionId, EndRunAndLearnSessionRequest request,
             LocalDateTime endTime) {
         // 세션 조회 및 소유자 검증
         RunAndLearnSession session = runAndLearnQueryService.findExistingSession(sessionId);
@@ -53,6 +56,11 @@ public class EndRunAndLearnSessionService {
 
         session.end(request.clientTotalScore(), endTime);
         runAndLearnCacheService.removeSessionQuestionIds(sessionId);
+
+        RunAndLearnRankingResult ranks = updateRunAndLearnRankingService.updateAndGetRanks(
+                session.getUser(), request.clientTotalScore(), endTime);
+
+        return EndRunAndLearnSessionResponse.of(ranks.weeklyRank(), ranks.allTimeRank());
     }
 
     private void validateSubmitCount(int submitCount, int totalQuestions) {

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/UpdateRunAndLearnRankingService.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/UpdateRunAndLearnRankingService.java
@@ -1,0 +1,64 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnRankingResult;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRanking;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSeasonCalculator;
+import com.gyu.engdu.domain.gamification.domain.enums.RankingType;
+import com.gyu.engdu.domain.user.domain.User;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateRunAndLearnRankingService {
+
+    private final RunAndLearnRankingRepository rankingRepository;
+
+    @Transactional
+    public RunAndLearnRankingResult updateAndGetRanks(User user, int score, LocalDateTime endedAt) {
+        int currentSeason = RunAndLearnSeasonCalculator.calculateSeason(endedAt);
+
+        // 주간 랭킹 업데이트 및 등수 조회
+        RunAndLearnRanking weeklyNewRanking = RunAndLearnRanking.createWeeklyRanking(user,
+                currentSeason,
+                score,
+                endedAt
+        );
+        RunAndLearnRanking weeklyRanking = upsertRanking(weeklyNewRanking, score, endedAt);
+        int myWeeklyRank = calculateMyRank(RankingType.WEEKLY, currentSeason, weeklyRanking.getBestScore());
+
+
+        // 역대 랭킹 업데이트 및 등수 조회
+        RunAndLearnRanking allTimeNewRanking = RunAndLearnRanking.createAllTimeRanking(
+                user,
+                score,
+                endedAt
+        );
+        RunAndLearnRanking allTimeRanking = upsertRanking(allTimeNewRanking, score, endedAt);
+        int myAllTimeRank = calculateMyRank(RankingType.ALL_TIME, allTimeRanking.getSeason(), allTimeRanking.getBestScore());
+
+        return RunAndLearnRankingResult.of(myWeeklyRank, myAllTimeRank);
+    }
+
+    private int calculateMyRank(RankingType rankingType, int season, int myBestScore) {
+        int higherScoreCount = rankingRepository.countByRankingTypeAndSeasonAndBestScoreGreaterThan(
+                rankingType,
+                season,
+                myBestScore
+        );
+        return higherScoreCount + 1;
+    }
+
+    private RunAndLearnRanking upsertRanking(RunAndLearnRanking newRanking, int score,
+            LocalDateTime achievedAt) {
+        RunAndLearnRanking ranking = rankingRepository.findByUserAndRankingTypeAndSeason(
+                        newRanking.getUser(), newRanking.getRankingType(), newRanking.getSeason())
+                .orElseGet(() -> rankingRepository.save(newRanking));
+
+        ranking.updateScoreIfHigher(score, achievedAt);
+        return ranking;
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/EndRunAndLearnSessionResponse.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/EndRunAndLearnSessionResponse.java
@@ -1,0 +1,10 @@
+package com.gyu.engdu.domain.gamification.application.dto.response;
+
+public record EndRunAndLearnSessionResponse(
+        long weeklyRank,
+        long allTimeRank
+) {
+    public static EndRunAndLearnSessionResponse of(long weeklyRank, long allTimeRank) {
+        return new EndRunAndLearnSessionResponse(weeklyRank, allTimeRank);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/RunAndLearnRankingResult.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/dto/response/RunAndLearnRankingResult.java
@@ -1,0 +1,10 @@
+package com.gyu.engdu.domain.gamification.application.dto.response;
+
+public record RunAndLearnRankingResult(
+        long weeklyRank,
+        long allTimeRank
+) {
+    public static RunAndLearnRankingResult of(long weeklyRank, long allTimeRank) {
+        return new RunAndLearnRankingResult(weeklyRank, allTimeRank);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRanking.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRanking.java
@@ -51,13 +51,33 @@ public class RunAndLearnRanking extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime achievedAt;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private RunAndLearnRanking(User user, RankingType rankingType, int season, int bestScore, LocalDateTime achievedAt) {
         this.user = user;
         this.rankingType = rankingType;
         this.season = season;
         this.bestScore = bestScore;
         this.achievedAt = achievedAt;
+    }
+
+    public static RunAndLearnRanking createWeeklyRanking(User user, int season, int bestScore, LocalDateTime achievedAt) {
+        return RunAndLearnRanking.builder()
+                .user(user)
+                .rankingType(RankingType.WEEKLY)
+                .season(season)
+                .bestScore(bestScore)
+                .achievedAt(achievedAt)
+                .build();
+    }
+
+    public static RunAndLearnRanking createAllTimeRanking(User user, int bestScore, LocalDateTime achievedAt) {
+        return RunAndLearnRanking.builder()
+                .user(user)
+                .rankingType(RankingType.ALL_TIME)
+                .season(0) // 역대 랭킹은 시즌을 0으로 고정
+                .bestScore(bestScore)
+                .achievedAt(achievedAt)
+                .build();
     }
 
     public void updateScoreIfHigher(int newScore, LocalDateTime achievedAt) {

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingRepository.java
@@ -1,0 +1,19 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import com.gyu.engdu.domain.gamification.domain.enums.RankingType;
+import com.gyu.engdu.domain.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RunAndLearnRankingRepository extends JpaRepository<RunAndLearnRanking, Long> {
+
+       Optional<RunAndLearnRanking> findByUserAndRankingTypeAndSeason(User user, RankingType rankingType, int season);
+
+       /**
+        * 특정 랭킹 타입과 시즌에서, 입력받은 점수보다 엄격히 높은 점수를 기록한 유저의 수를 반환합니다.
+        * SELECT count(*)
+        * FROM run_and_learn_ranking
+        * WHERE ranking_type = ? AND season = ? AND best_score > ?
+        */
+       int countByRankingTypeAndSeasonAndBestScoreGreaterThan(RankingType rankingType, int season, int bestScore);
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSeasonCalculator.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSeasonCalculator.java
@@ -1,0 +1,35 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import com.gyu.engdu.domain.gamification.exception.InvalidRunAndLearnSeasonDateException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RunAndLearnSeasonCalculator {
+
+    private static final LocalDate BASE_DATE = LocalDate.of(2026, 6, 1);
+
+
+    /**
+     * 2026년 6월 1일(월)은 시즌 1입니다.
+     * 매주 월요일마다 시즌이 1씩 증가합니다.
+     * 타겟 시간의 시즌을 계산합니다.
+     */
+    public static int calculateSeason(LocalDateTime targetDateTime) {
+        if (targetDateTime == null) {
+            throw new InvalidRunAndLearnSeasonDateException("타겟 날짜는 null일 수 없습니다.");
+        }
+
+        LocalDate targetDate = targetDateTime.toLocalDate();
+
+        if (targetDate.isBefore(BASE_DATE)) {
+            throw new InvalidRunAndLearnSeasonDateException("타겟 날짜는 기준일(2026-06-01) 이전일 수 없습니다.");
+        }
+
+        long weeks = ChronoUnit.WEEKS.between(BASE_DATE, targetDate);
+        return (int) weeks + 1;
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnSeasonDateException.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/exception/InvalidRunAndLearnSeasonDateException.java
@@ -1,0 +1,14 @@
+package com.gyu.engdu.domain.gamification.exception;
+
+import com.gyu.engdu.global.exception.ErrorCode;
+import com.gyu.engdu.global.exception.ValidationException;
+
+public class InvalidRunAndLearnSeasonDateException extends ValidationException {
+    public InvalidRunAndLearnSeasonDateException() {
+        super(ErrorCode.RUN_AND_LEARN_INVALID_SEASON_DATE);
+    }
+
+    public InvalidRunAndLearnSeasonDateException(String message) {
+        super(ErrorCode.RUN_AND_LEARN_INVALID_SEASON_DATE, message);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/presentation/RunAndLearnController.java
@@ -6,6 +6,7 @@ import com.gyu.engdu.domain.gamification.application.RunAndLearnQueryService;
 import com.gyu.engdu.domain.gamification.application.StartRunAndLearnSessionService;
 import com.gyu.engdu.domain.gamification.application.dto.request.EndRunAndLearnSessionRequest;
 import com.gyu.engdu.domain.gamification.application.dto.response.CreateRunAndLearnSessionResponse;
+import com.gyu.engdu.domain.gamification.application.dto.response.EndRunAndLearnSessionResponse;
 import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnQuestionResponse;
 import com.gyu.engdu.domain.gamification.application.dto.response.StartRunAndLearnSessionResponse;
 import com.gyu.engdu.domain.gamification.presentation.dto.request.RunAndLearnQuestionRequest;
@@ -65,12 +66,12 @@ public class RunAndLearnController {
     }
 
     @PostMapping("/{sessionId}/end")
-    public ResponseEntity<Void> endSession(@PathVariable("sessionId") Long sessionId,
+    public ResponseEntity<EndRunAndLearnSessionResponse> endSession(@PathVariable("sessionId") Long sessionId,
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @Valid @RequestBody EndRunAndLearnSessionRequest request) {
 
-        endRunAndLearnSessionService.endSession(userId, sessionId, request, LocalDateTime.now());
+        EndRunAndLearnSessionResponse response = endRunAndLearnSessionService.endSession(userId, sessionId, request, LocalDateTime.now());
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
+++ b/src/main/java/com/gyu/engdu/global/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
   RUN_AND_LEARN_WRONG_ANSWER_BEFORE_END("GAMIFICATION-010", "오답이 발생했지만 게임이 종료되지 않았습니다."),
   RUN_AND_LEARN_INVALID_END("GAMIFICATION-011", "마지막 문제를 맞추었으나 게임이 비정상적으로 종료되었습니다."),
   RUN_AND_LEARN_SCORE_MISMATCH("GAMIFICATION-012", "클라이언트 점수와 서버에서 계산된 점수가 일치하지 않습니다."),
+  RUN_AND_LEARN_INVALID_SEASON_DATE("GAMIFICATION-013", "유효하지 않은 런앤런 시즌 날짜입니다."),
 
   // Spring Standard Errors
   INVALID_INPUT_VALUE("COMMON-001", "잘못된 입력값입니다."),

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/UpdateRunAndLearnRankingServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/UpdateRunAndLearnRankingServiceTest.java
@@ -1,0 +1,216 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gyu.engdu.IntegrationTestSupport;
+import com.gyu.engdu.domain.gamification.application.dto.response.RunAndLearnRankingResult;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRanking;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
+import com.gyu.engdu.domain.gamification.domain.enums.RankingType;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.domain.user.domain.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class UpdateRunAndLearnRankingServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UpdateRunAndLearnRankingService updateRunAndLearnRankingService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RunAndLearnRankingRepository runAndLearnRankingRepository;
+
+    @Test
+    @DisplayName("처음으로 런앤런 세션을 종료하여 점수를 등록하면 주간, 역대 모두 1등이다.")
+    void updateAndGetRanks_firstScore() {
+        // given
+        User user = userRepository.save(createUser("user1@test.com", "sub1", "user1"));
+        LocalDateTime endedAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+        int season1 = 1;
+        int score = 100;
+
+        // when
+        RunAndLearnRankingResult result = updateRunAndLearnRankingService.updateAndGetRanks(user,
+                score, endedAt);
+
+        // then
+        RunAndLearnRanking weeklyRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.WEEKLY, season1).orElseThrow();
+        RunAndLearnRanking allTimeRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.ALL_TIME, 0).orElseThrow();
+
+        assertThat(result.weeklyRank()).isEqualTo(1);
+        assertThat(result.allTimeRank()).isEqualTo(1);
+        assertThat(weeklyRanking.getBestScore()).isEqualTo(score);
+        assertThat(allTimeRanking.getBestScore()).isEqualTo(score);
+    }
+
+    @Test
+    @DisplayName("유저의 등수는 자신보다 높은 점수를 가진 유저의 수 + 1이다.")
+    void updateAndGetRanks_rankIsHigherScoreUserCountPlusOne() {
+        // given
+        User user1 = userRepository.save(createUser("user1@test.com", "sub1", "user1"));
+        User user2 = userRepository.save(createUser("user2@test.com", "sub2", "user2"));
+        User user3 = userRepository.save(createUser("user3@test.com", "sub3", "user3"));
+        User targetUser = userRepository.save(createUser("target@test.com", "target", "target"));
+
+        LocalDateTime endedAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+        int user1Score = 200;
+        int user2Score = 200;
+        int user3Score = 150;
+        int targetScore = 100;
+
+        updateRunAndLearnRankingService.updateAndGetRanks(user1, user1Score, endedAt);
+        updateRunAndLearnRankingService.updateAndGetRanks(user2, user2Score, endedAt);
+        updateRunAndLearnRankingService.updateAndGetRanks(user3, user3Score, endedAt);
+
+        // when
+        RunAndLearnRankingResult result = updateRunAndLearnRankingService.updateAndGetRanks(
+                targetUser, targetScore,
+                endedAt);
+
+        // then
+        assertThat(result.weeklyRank()).isEqualTo(4);
+        assertThat(result.allTimeRank()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("기존 최고 점수보다 더 낮은 점수를 등록하면 랭킹 점수가 갱신되지 않는다.")
+    void updateAndGetRanks_lowerScore_notUpdated() {
+        // given
+        User user = userRepository.save(createUser("user1@test.com", "sub1", "user1"));
+        LocalDateTime endedAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+        int season1 = 1;
+        int initialScore = 100;
+        int lowerScore = 50;
+
+        updateRunAndLearnRankingService.updateAndGetRanks(user, initialScore, endedAt);
+
+        // when
+        LocalDateTime later = endedAt.plusMinutes(10);
+        updateRunAndLearnRankingService.updateAndGetRanks(user, lowerScore, later);
+
+        // then
+        RunAndLearnRanking weeklyRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.WEEKLY, season1).orElseThrow();
+
+        assertThat(weeklyRanking.getBestScore()).isEqualTo(100); // 50점으로 갱신되지 않음
+        assertThat(weeklyRanking.getAchievedAt()).isEqualTo(endedAt); // 처음 달성한 시간 유지
+    }
+
+    @Test
+    @DisplayName("기존 최고 점수보다 더 높은 점수를 등록하면 랭킹 점수가 갱신된다.")
+    void updateAndGetRanks_higherScore_updated() {
+        // given
+        User user1 = userRepository.save(createUser("user1@test.com", "sub1", "user1"));
+        User user2 = userRepository.save(createUser("user2@test.com", "sub2", "user2"));
+        LocalDateTime endedAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+        int season1 = 1;
+        int user1InitialScore = 100;
+        int user2Score = 150;
+        int user1HigherScore = 200;
+
+        updateRunAndLearnRankingService.updateAndGetRanks(user1, user1InitialScore, endedAt);
+        updateRunAndLearnRankingService.updateAndGetRanks(user2, user2Score,
+                endedAt); // user2가 1등, user1이 2등
+
+        // when
+        LocalDateTime later = endedAt.plusMinutes(10);
+        RunAndLearnRankingResult result = updateRunAndLearnRankingService.updateAndGetRanks(user1,
+                user1HigherScore,
+                later);
+
+        // then
+        RunAndLearnRanking weeklyRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user1, RankingType.WEEKLY, season1).orElseThrow();
+        RunAndLearnRanking allTimeRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user1, RankingType.ALL_TIME, 0).orElseThrow();
+
+        assertThat(result.weeklyRank()).isEqualTo(1);
+        assertThat(result.allTimeRank()).isEqualTo(1);
+        assertThat(weeklyRanking.getBestScore()).isEqualTo(200);
+        assertThat(weeklyRanking.getAchievedAt()).isEqualTo(later);
+    }
+
+    @Test
+    @DisplayName("새로운 시즌에 이전 역대 최고 점수보다 높은 점수를 등록하면, 주간/역대 점수가 모두 갱신된다.")
+    void updateAndGetRanks_differentSeason_higherScore_allTimeUpdated() {
+        // given
+        int season2 = 2;
+        int allTimeSeason = 0;
+        User user = userRepository.save(createUser("user1@test.com", "sub1", "user1"));
+        LocalDateTime season1Date = LocalDateTime.of(2026, 6, 1, 10, 0); // 시즌 1
+        int season1Score = 100;
+
+        updateRunAndLearnRankingService.updateAndGetRanks(user, season1Score, season1Date);
+
+        // when
+        LocalDateTime season2Date = LocalDateTime.of(2026, 6, 8, 10, 0); // 시즌 2
+        int season2HigherScore = 150;
+        RunAndLearnRankingResult result = updateRunAndLearnRankingService.updateAndGetRanks(user,
+                season2HigherScore,
+                season2Date);
+
+        // then
+        RunAndLearnRanking weeklyRankingSeason2 = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.WEEKLY, season2).orElseThrow();
+
+        RunAndLearnRanking allTimeRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.ALL_TIME, allTimeSeason).orElseThrow();
+
+        assertThat(result.weeklyRank()).isEqualTo(1);
+        assertThat(result.allTimeRank()).isEqualTo(1);
+        assertThat(weeklyRankingSeason2.getBestScore()).isEqualTo(150);
+        assertThat(allTimeRanking.getBestScore()).isEqualTo(150);
+    }
+
+    @Test
+    @DisplayName("새로운 시즌에 이전 역대 최고 점수보다 낮은 점수를 등록하면, 주간 점수만 갱신되고 역대 최고 점수는 유지된다.")
+    void updateAndGetRanks_differentSeason_lowerScore_allTimeNotUpdated() {
+        // given
+        User user = userRepository.save(createUser("user1@test.com", "sub1", "user1"));
+        LocalDateTime season1Date = LocalDateTime.of(2026, 6, 1, 10, 0); // 시즌 1
+        int season1Score = 100;
+        int season2 = 2;
+
+        updateRunAndLearnRankingService.updateAndGetRanks(user, season1Score, season1Date);
+
+        // when
+        LocalDateTime season2Date = LocalDateTime.of(2026, 6, 8, 10, 0); // 시즌 2 (1주일 뒤)
+        int season2LowerScore = 50;
+        RunAndLearnRankingResult result = updateRunAndLearnRankingService.updateAndGetRanks(user,
+                season2LowerScore,
+                season2Date);
+
+        // then
+        RunAndLearnRanking weeklyRankingSeason2 = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.WEEKLY, season2).orElseThrow();
+
+        RunAndLearnRanking allTimeRanking = runAndLearnRankingRepository.findByUserAndRankingTypeAndSeason(
+                user, RankingType.ALL_TIME, 0).orElseThrow();
+
+        assertThat(result.weeklyRank()).isEqualTo(1); // 시즌 2에서는 50점이라도 혼자이므로 1등
+        assertThat(result.allTimeRank()).isEqualTo(1); // 역대 100점 기준으로 1등
+        assertThat(weeklyRankingSeason2.getBestScore()).isEqualTo(50); // 주간은 50점
+        assertThat(allTimeRanking.getBestScore()).isEqualTo(100); // 역대는 100점 유지
+    }
+
+    private User createUser(String email, String sub, String name) {
+        return User.builder()
+                .email(email)
+                .role(Role.ROLE_USER)
+                .sub(sub)
+                .name(name)
+                .build();
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingTest.java
@@ -1,0 +1,116 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gyu.engdu.domain.gamification.domain.enums.RankingType;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RunAndLearnRankingTest {
+
+    @Test
+    @DisplayName("주간 랭킹 엔티티를 생성하면 랭킹 타입이 WEEKLY이고 전달한 시즌이 설정된다.")
+    void createWeeklyRanking() {
+        // given
+        User user = createUser();
+        int season = 1;
+        int bestScore = 150;
+        LocalDateTime achievedAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+        // when
+        RunAndLearnRanking weeklyRanking = RunAndLearnRanking.createWeeklyRanking(user, season, bestScore, achievedAt);
+
+        // then
+        assertThat(weeklyRanking.getUser()).isEqualTo(user);
+        assertThat(weeklyRanking.getRankingType()).isEqualTo(RankingType.WEEKLY);
+        assertThat(weeklyRanking.getSeason()).isEqualTo(season);
+        assertThat(weeklyRanking.getBestScore()).isEqualTo(bestScore);
+        assertThat(weeklyRanking.getAchievedAt()).isEqualTo(achievedAt);
+    }
+
+    @Test
+    @DisplayName("역대 랭킹 엔티티를 생성하면 랭킹 타입이 ALL_TIME이고 시즌이 0으로 고정된다.")
+    void createAllTimeRanking() {
+        // given
+        User user = createUser();
+        int bestScore = 200;
+        LocalDateTime achievedAt = LocalDateTime.of(2026, 6, 1, 10, 0);
+
+        // when
+        RunAndLearnRanking allTimeRanking = RunAndLearnRanking.createAllTimeRanking(user, bestScore, achievedAt);
+
+        // then
+        assertThat(allTimeRanking.getUser()).isEqualTo(user);
+        assertThat(allTimeRanking.getRankingType()).isEqualTo(RankingType.ALL_TIME);
+        assertThat(allTimeRanking.getSeason()).isZero();
+        assertThat(allTimeRanking.getBestScore()).isEqualTo(bestScore);
+        assertThat(allTimeRanking.getAchievedAt()).isEqualTo(achievedAt);
+    }
+
+    @Test
+    @DisplayName("기존보다 더 높은 점수를 업데이트하면 최고 점수와 달성 시간이 갱신된다.")
+    void updateScoreIfHigher_higherScore() {
+        // given
+        User user = createUser();
+        LocalDateTime originalTime = LocalDateTime.of(2026, 6, 1, 10, 0);
+        int currentScore = 100;
+        RunAndLearnRanking ranking = RunAndLearnRanking.createWeeklyRanking(user, 1, currentScore, originalTime);
+
+        // when
+        int higherScore = 150;
+        LocalDateTime newTime = originalTime.plusDays(1);
+        ranking.updateScoreIfHigher(higherScore, newTime);
+
+        // then
+        assertThat(ranking.getBestScore()).isEqualTo(higherScore);
+        assertThat(ranking.getAchievedAt()).isEqualTo(newTime);
+    }
+
+    @Test
+    @DisplayName("기존보다 낮은 점수를 업데이트하면 최고 점수와 달성 시간이 갱신되지 않는다.")
+    void updateScoreIfHigher_lowerScore() {
+        // given
+        User user = createUser();
+        LocalDateTime originalTime = LocalDateTime.of(2026, 6, 1, 10, 0);
+        int currentScore = 100;
+        int lowerScore = 50;
+        RunAndLearnRanking ranking = RunAndLearnRanking.createWeeklyRanking(user, 1, currentScore, originalTime);
+
+        // when
+        ranking.updateScoreIfHigher(lowerScore, originalTime.plusDays(1));
+
+        // then
+        assertThat(ranking.getBestScore()).isEqualTo(currentScore);
+        assertThat(ranking.getAchievedAt()).isEqualTo(originalTime);
+    }
+
+    @Test
+    @DisplayName("기존과 같은 점수를 업데이트하면 최고 점수와 달성 시간이 갱신되지 않는다.")
+    void updateScoreIfHigher_equalScore() {
+        // given
+        User user = createUser();
+        LocalDateTime originalTime = LocalDateTime.of(2026, 6, 1, 10, 0);
+        int currentScore = 100;
+        int equalScore = 100;
+        RunAndLearnRanking ranking = RunAndLearnRanking.createWeeklyRanking(user, 1, currentScore, originalTime);
+
+        // when
+        ranking.updateScoreIfHigher(equalScore, originalTime.plusDays(2));
+
+        // then
+        assertThat(ranking.getBestScore()).isEqualTo(currentScore);
+        assertThat(ranking.getAchievedAt()).isEqualTo(originalTime);
+    }
+
+    private User createUser() {
+        return User.builder()
+                .email("test@test.com")
+                .role(Role.ROLE_USER)
+                .sub("sub123")
+                .name("testUser")
+                .build();
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSeasonCalculatorTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSeasonCalculatorTest.java
@@ -1,0 +1,80 @@
+package com.gyu.engdu.domain.gamification.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.gyu.engdu.domain.gamification.exception.InvalidRunAndLearnSeasonDateException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RunAndLearnSeasonCalculatorTest {
+
+    @Test
+    @DisplayName("2026년 6월 1일(월)은 기준일로 시즌 1이다.")
+    void calculateSeason_baseDate_isSeason1() {
+        // given
+        LocalDateTime baseDate = LocalDateTime.of(2026, 6, 1, 0, 0);
+        int season1 = 1;
+
+        // when
+        int season = RunAndLearnSeasonCalculator.calculateSeason(baseDate);
+
+        // then
+        assertThat(season).isEqualTo(season1);
+    }
+
+    @Test
+    @DisplayName("같은 주차의 월요일, 수요일, 일요일은 모두 동일한 시즌을 갖는다.")
+    void calculateSeason_sameWeek_sameSeason() {
+        // given
+        LocalDateTime monday = LocalDateTime.of(2026, 6, 1, 0, 0);
+        LocalDateTime wednesday = LocalDateTime.of(2026, 6, 3, 0, 0);
+        LocalDateTime sunday = LocalDateTime.of(2026, 6, 7, 0, 0);
+        int expectedSeason = 1;
+
+        // when
+        int mondaySeason = RunAndLearnSeasonCalculator.calculateSeason(monday);
+        int wednesdaySeason = RunAndLearnSeasonCalculator.calculateSeason(wednesday);
+        int sundaySeason = RunAndLearnSeasonCalculator.calculateSeason(sunday);
+
+        // then
+        assertThat(mondaySeason).isEqualTo(expectedSeason);
+        assertThat(wednesdaySeason).isEqualTo(expectedSeason);
+        assertThat(sundaySeason).isEqualTo(expectedSeason);
+    }
+
+    @Test
+    @DisplayName("기준일로부터 주차가 지나면 시즌이 1씩 커진다.")
+    void calculateSeason_nextWeeks_incrementSeason() {
+        // given
+        LocalDateTime season1Monday = LocalDateTime.of(2026, 6, 1, 0, 0);
+        LocalDateTime season2Monday = LocalDateTime.of(2026, 6, 8, 0, 0);
+        LocalDateTime season3Monday = LocalDateTime.of(2026, 6, 15, 0, 0);
+        LocalDateTime season10Monday = LocalDateTime.of(2026, 8, 3, 0, 0);
+
+        // when
+        int season1 = RunAndLearnSeasonCalculator.calculateSeason(season1Monday);
+        int season2 = RunAndLearnSeasonCalculator.calculateSeason(season2Monday);
+        int season3 = RunAndLearnSeasonCalculator.calculateSeason(season3Monday);
+        int season10 = RunAndLearnSeasonCalculator.calculateSeason(season10Monday);
+
+        // then
+        assertThat(season1).isEqualTo(1);
+        assertThat(season2).isEqualTo(2);
+        assertThat(season3).isEqualTo(3);
+        assertThat(season10).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("기준일 이전의 날짜는 예외가 발생한다.")
+    void calculateSeason_beforeBaseDate_throwsException() {
+        // given
+        LocalDateTime beforeBaseDate = LocalDateTime.of(2026, 5, 31, 23, 59);
+
+        // when & then
+        assertThatThrownBy(
+                () -> RunAndLearnSeasonCalculator.calculateSeason(beforeBaseDate)).isInstanceOf(
+                InvalidRunAndLearnSeasonDateException.class);
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
- closed #139

## 작업 내용
### 개요
런앤런 세션 종료 시 사용자의 점수를 기반으로 주간 및 역대 랭킹을 업데이트하고, 최종 등수(주간/역대)를 반환하는 기능을 추가하였습니다.
### 변경 사항
- **랭킹 도메인 모델 보완 (RunAndLearnRanking.java)**
   - 주간 및 역대 랭킹 생성을 위한 팩토리 메서드(`createWeeklyRanking`, `createAllTimeRanking`)를 추가하였습니다.
- **시즌 계산기 구현 (RunAndLearnSeasonCalculator.java)**
   - 2026년 6월 1일을 기준일(시즌 1)로 하여 매주 월요일마다 시즌 번호가 1씩 증가하도록 시즌 계산 기능을 구현하였습니다.
- **랭킹 업데이트 비즈니스 로직 추가 (UpdateRunAndLearnRankingService.java, RunAndLearnRankingRepository.java)**
   - 주간 및 역대 랭킹의 최고점을 갱신(Upsert)하는 로직을 작성하였습니다.
   - 랭킹 데이터베이스에서 본인보다 높은 점수를 얻은 유저 수를 조회하여 현재 등수를 계산하는 기능을 추가하였습니다.
- **세션 종료 흐름 연동 (EndRunAndLearnSessionService.java, RunAndLearnController.java)**
   - 세션이 종료될 때 랭킹을 업데이트하고 최종 등수를 반환하도록 로직을 변경하였습니다.
   - 종료 API(`POST /api/v1/run-and-learn/{sessionId}/end`)의 응답 타입을 `EndRunAndLearnSessionResponse`로 수정하여 주간/역대 등수를 클라이언트에 응답하도록 구현하였습니다.

- **테스트 코드 구현**
   - `RunAndLearnSeasonCalculatorTest.java`: 시즌 계산 로직 및 입력값 예외를 검증하였습니다.
   - `RunAndLearnRankingTest.java`: 랭킹 정보 생성 및 스코어 갱신 조건을 검증하였습니다.
   - `UpdateRunAndLearnRankingServiceTest.java`: 주간/역대 랭킹이 정상 갱신되는지, 동점자 및 점수 차이에 따른 등수 계산이 제대로 동작하는지 통합 테스트를 수행하였습니다.

