### PR TITLE
[FIX] 회원 탈퇴 시 리더보드 랭킹이 안보이는 문제 해결

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionListener.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionListener.java
@@ -1,0 +1,23 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.user.domain.event.UserDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RunAndLearnUserDeletionListener {
+
+    private final RunAndLearnRankingRepository runAndLearnRankingRepository;
+    private final RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @EventListener
+    public void handleUserDeletedEvent(UserDeletedEvent event) {
+        Long userId = event.userId();
+        runAndLearnRankingRepository.deleteByUserId(userId);
+        runAndLearnSessionRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRanking.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRanking.java
@@ -4,10 +4,12 @@ import com.gyu.engdu.domain.BaseEntity;
 import com.gyu.engdu.domain.gamification.domain.enums.RankingType;
 import com.gyu.engdu.domain.user.domain.User;
 import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,7 +38,7 @@ public class RunAndLearnRanking extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingRepository.java
@@ -33,4 +33,8 @@ public interface RunAndLearnRankingRepository extends JpaRepository<RunAndLearnR
             RankingType rankingType,
             int season, Pageable pageable
     );
+
+    void deleteByUserId(Long userId);
+
+    List<RunAndLearnRanking> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionRepository.java
@@ -1,7 +1,12 @@
 package com.gyu.engdu.domain.gamification.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RunAndLearnSessionRepository extends JpaRepository<RunAndLearnSession, Long> {
+
+    void deleteByUserId(Long userId);
+
+    List<RunAndLearnSession> findAllByUserId(Long userId);
 
 }

--- a/src/main/java/com/gyu/engdu/domain/user/application/DeleteUserService.java
+++ b/src/main/java/com/gyu/engdu/domain/user/application/DeleteUserService.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.context.ApplicationEventPublisher;
+import com.gyu.engdu.domain.user.domain.event.UserDeletedEvent;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -13,9 +16,11 @@ public class DeleteUserService {
 
   private final UserRepository userRepository;
   private final UserQueryService userQueryService;
+  private final ApplicationEventPublisher eventPublisher;
 
   public void delete(Long userId) {
     User user = userQueryService.findExistingUser(userId);
     userRepository.delete(user);
+    eventPublisher.publishEvent(new UserDeletedEvent(userId));
   }
 }

--- a/src/main/java/com/gyu/engdu/domain/user/domain/event/UserDeletedEvent.java
+++ b/src/main/java/com/gyu/engdu/domain/user/domain/event/UserDeletedEvent.java
@@ -1,0 +1,4 @@
+package com.gyu.engdu.domain.user.domain.event;
+
+public record UserDeletedEvent(Long userId) {
+}

--- a/src/test/java/com/gyu/engdu/domain/auth/application/LogoutServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/auth/application/LogoutServiceTest.java
@@ -7,9 +7,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@Transactional
 class LogoutServiceTest extends IntegrationTestSupport {
 
   @Autowired
@@ -21,15 +21,15 @@ class LogoutServiceTest extends IntegrationTestSupport {
   @DisplayName("로그아웃시 사용자 기기의 리프레시 토큰 엔티티가 삭제된다.")
   @Test
   void logout() {
-    //given
+    // given
     String rawRefreshToken = "test_token";
     RefreshToken refreshToken = createRefreshToken(1L, rawRefreshToken);
     refreshTokenRepository.save(refreshToken);
 
-    //when
+    // when
     logoutService.logout(rawRefreshToken);
 
-    //then
+    // then
     boolean isDeleted = refreshTokenRepository.findByRawToken(rawRefreshToken).isEmpty();
     Assertions.assertThat(isDeleted).isTrue();
 

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionIntegrationTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.gyu.engdu.IntegrationTestSupport;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRanking;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSession;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.user.application.DeleteUserService;
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.domain.user.domain.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class RunAndLearnUserDeletionIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private DeleteUserService deleteUserService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RunAndLearnRankingRepository runAndLearnRankingRepository;
+
+    @Autowired
+    private RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Test
+    @DisplayName("회원 탈퇴 시 RunAndLearnRanking과 RunAndLearnSession이 삭제된다")
+    void deleteUser_ShouldDeleteGamificationData() {
+        // given
+        User targetUser = createUser("target@test.com", "sub1", "Target");
+        userRepository.save(targetUser);
+
+        User otherUser = createUser("other@test.com", "sub2", "Other");
+        userRepository.save(otherUser);
+
+        // Target 회원의 데이터 세팅
+        runAndLearnRankingRepository.save(
+                RunAndLearnRanking.createWeeklyRanking(targetUser, 1, 100, LocalDateTime.now()));
+        runAndLearnSessionRepository.save(RunAndLearnSession.of(targetUser, 123));
+
+        // Other 회원의 데이터 세팅 (노이즈)
+        runAndLearnRankingRepository.save(
+                RunAndLearnRanking.createWeeklyRanking(otherUser, 1, 200, LocalDateTime.now()));
+        runAndLearnSessionRepository.save(RunAndLearnSession.of(otherUser, 456));
+
+        // when
+        deleteUserService.delete(targetUser.getId());
+
+        // then
+        assertThat(userRepository.findById(targetUser.getId())).isEmpty();
+
+        List<RunAndLearnRanking> targetRankings = runAndLearnRankingRepository.findAllByUserId(
+                targetUser.getId());
+        assertThat(targetRankings).isEmpty();
+
+        List<RunAndLearnSession> targetSessions = runAndLearnSessionRepository.findAllByUserId(
+                targetUser.getId());
+        assertThat(targetSessions).isEmpty();
+
+        // Other 회원의 데이터는 남아있어야 함
+        assertThat(userRepository.findById(otherUser.getId())).isPresent();
+
+        List<RunAndLearnRanking> otherRankings = runAndLearnRankingRepository.findAllByUserId(
+                otherUser.getId());
+        assertThat(otherRankings).hasSize(1);
+
+        List<RunAndLearnSession> otherSessions = runAndLearnSessionRepository.findAllByUserId(
+                otherUser.getId());
+        assertThat(otherSessions).hasSize(1);
+    }
+
+    private User createUser(String email, String sub, String name) {
+        return User.builder()
+                .email(email)
+                .role(Role.ROLE_USER)
+                .sub(sub)
+                .name(name)
+                .build();
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionIntegrationTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionIntegrationTest.java
@@ -11,12 +11,15 @@ import com.gyu.engdu.domain.user.application.DeleteUserService;
 import com.gyu.engdu.domain.user.domain.Role;
 import com.gyu.engdu.domain.user.domain.User;
 import com.gyu.engdu.domain.user.domain.UserRepository;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 class RunAndLearnUserDeletionIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
@@ -30,6 +33,9 @@ class RunAndLearnUserDeletionIntegrationTest extends IntegrationTestSupport {
 
     @Autowired
     private RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Autowired
+    private EntityManager em;
 
     @Test
     @DisplayName("회원 탈퇴 시 RunAndLearnRanking과 RunAndLearnSession이 삭제된다")
@@ -51,6 +57,8 @@ class RunAndLearnUserDeletionIntegrationTest extends IntegrationTestSupport {
                 RunAndLearnRanking.createWeeklyRanking(otherUser, 1, 200, LocalDateTime.now()));
         runAndLearnSessionRepository.save(RunAndLearnSession.of(otherUser, 456));
 
+        em.flush();
+        em.clear();
         // when
         deleteUserService.delete(targetUser.getId());
 

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionListenerTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionListenerTest.java
@@ -1,0 +1,41 @@
+package com.gyu.engdu.domain.gamification.application;
+
+import static org.mockito.Mockito.verify;
+
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
+import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
+import com.gyu.engdu.domain.user.domain.event.UserDeletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RunAndLearnUserDeletionListenerTest {
+
+    @InjectMocks
+    private RunAndLearnUserDeletionListener runAndLearnUserDeletionListener;
+
+    @Mock
+    private RunAndLearnRankingRepository runAndLearnRankingRepository;
+
+    @Mock
+    private RunAndLearnSessionRepository runAndLearnSessionRepository;
+
+    @Test
+    @DisplayName("UserDeletedEvent가 수신되면 관련된 랭킹과 세션이 삭제된다")
+    void handleUserDeletedEvent_ShouldDeleteRelatedData() {
+        // given
+        Long deletedUserId = 1L;
+        UserDeletedEvent event = new UserDeletedEvent(deletedUserId);
+
+        // when
+        runAndLearnUserDeletionListener.handleUserDeletedEvent(event);
+
+        // then
+        verify(runAndLearnRankingRepository).deleteByUserId(deletedUserId);
+        verify(runAndLearnSessionRepository).deleteByUserId(deletedUserId);
+    }
+}

--- a/src/test/java/com/gyu/engdu/domain/user/application/DeleteUserServiceTest.java
+++ b/src/test/java/com/gyu/engdu/domain/user/application/DeleteUserServiceTest.java
@@ -1,0 +1,64 @@
+package com.gyu.engdu.domain.user.application;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.gyu.engdu.domain.user.domain.Role;
+import com.gyu.engdu.domain.user.domain.User;
+import com.gyu.engdu.domain.user.domain.UserRepository;
+import com.gyu.engdu.domain.user.domain.event.UserDeletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteUserServiceTest {
+
+    @InjectMocks
+    private DeleteUserService deleteUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserQueryService userQueryService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Test
+    @DisplayName("회원 삭제 시 userRepository.delete가 호출되고 UserDeletedEvent가 발행된다")
+    void deleteUser_ShouldCallDeleteAndPublishEvent() {
+        // given
+        Long userId = 1L;
+        User user = createUser("test@test.com", "sub123", "TestUser");
+        given(userQueryService.findExistingUser(userId)).willReturn(user);
+
+        // when
+        deleteUserService.delete(userId);
+
+        // then
+        verify(userRepository).delete(user);
+        
+        ArgumentCaptor<UserDeletedEvent> eventCaptor = ArgumentCaptor.forClass(UserDeletedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        
+        UserDeletedEvent publishedEvent = eventCaptor.getValue();
+        assertThat(publishedEvent.userId()).isEqualTo(userId);
+    }
+
+    private User createUser(String email, String sub, String name) {
+        return User.builder()
+                .email(email)
+                .role(Role.ROLE_USER)
+                .sub(sub)
+                .name(name)
+                .build();
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
- closed #153

## 작업 내용

### 개요
- 회원 탈퇴 시 리더보드에 기존 유저의 랭킹 정보가 남아 있고, 이를 조회할 때 유저 데이터가 존재하지 않아 에러가 발생하는 문제를 해결했습니다.
- 도메인 간 결합도를 낮추기 위해 스프링 이벤트를 활용한 연쇄 삭제 전략을 구현했습니다.

### 변경 사항
- **이벤트 정의 (`UserDeletedEvent.java`)**
  - 유저 삭제 사실을 도메인 외부에 알리기 위한 이벤트를 정의했습니다.
- **이벤트 발행 로직 추가 (`DeleteUserService.java`)**
  - 회원 탈퇴 로직이 성공적으로 수행된 직후 이벤트를 발행하도록 변경했습니다.
- **이벤트 수신 로직 추가 (`RunAndLearnUserDeletionListener.java`, `RunAndLearnRankingRepository.java` 등)**
  - 이벤트를 구독하여 기존에 남겨져 있던 게이미피케이션 랭킹 및 세션 데이터를 삭제하는 리스너를 구현했습니다.
  - H2 환경 등에서 외래 키 제약 조건 에러를 방지하기 위해 랭킹 엔티티에 `ConstraintMode.NO_CONSTRAINT` 옵션을 추가했습니다.
- **테스트 작성 (`RunAndLearnUserDeletionIntegrationTest.java` 등)**
  - 엔티티 팩터리 메서드 대신 테스트 내부 빌더 헬퍼(`createUser`)를 직접 활용하도록 작성했습니다.
  - 전체 단위 테스트 및 통합 테스트를 성공적으로 통과하도록 커버리지를 채웠습니다.