### PR TITLE
[REFACTOR] 런앤런 연관 데이터 벌크 삭제 최적화

### DIFF
--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnRankingRepository.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RunAndLearnRankingRepository extends JpaRepository<RunAndLearnRanking, Long> {
 
@@ -34,7 +37,9 @@ public interface RunAndLearnRankingRepository extends JpaRepository<RunAndLearnR
             int season, Pageable pageable
     );
 
-    void deleteByUserId(Long userId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from RunAndLearnRanking r where r.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 
     List<RunAndLearnRanking> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionRepository.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/domain/RunAndLearnSessionRepository.java
@@ -2,10 +2,15 @@ package com.gyu.engdu.domain.gamification.domain;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RunAndLearnSessionRepository extends JpaRepository<RunAndLearnSession, Long> {
 
-    void deleteByUserId(Long userId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from RunAndLearnSession r where r.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 
     List<RunAndLearnSession> findAllByUserId(Long userId);
 

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionIntegrationTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionIntegrationTest.java
@@ -59,6 +59,7 @@ class RunAndLearnUserDeletionIntegrationTest extends IntegrationTestSupport {
 
         em.flush();
         em.clear();
+
         // when
         deleteUserService.delete(targetUser.getId());
 


### PR DESCRIPTION
## 연관된 이슈
- closed #156

## 작업 내용

### 개요
- 회원 탈퇴 과정에서 연관된 런앤런 게임 데이터를 삭제할 때, 불필요한 N+1 Select 쿼리를 방지하기 위해 JPA 벌크 연산으로 로직을 최적화했습니다.

### 변경 사항
- **런앤런 세션 리포지토리 (`RunAndLearnSessionRepository.java`)**
  - 파생 쿼리를 `@Query`와 `@Modifying(clearAutomatically = true, flushAutomatically = true)`를 활용한 벌크 연산으로 변경하여 쿼리 호출을 1회로 최적화했습니다.
- **런앤런 랭킹 리포지토리 (`RunAndLearnRankingRepository.java`)**
  - 동일하게 벌크 연산을 적용하여 리소스 낭비를 방지했습니다.