### PR TITLE
[FEAT] 회원 가입 디스코드 웹훅 연동 및 리스너 패키지 구조 개선

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -114,13 +114,14 @@ CREATE TABLE `message` (
 -- RunAndLearnSession Table
 CREATE TABLE `run_and_learn_session` (
     `run_and_learn_session_id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `created_at` DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `modified_at` DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     `user_id` BIGINT,
     `seed` INT NOT NULL,
     `score` INT NOT NULL,
     `started_at` DATETIME(6) NULL,
     `ended_at` DATETIME(6) NULL,
-    `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    `updated_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+    `status` VARCHAR(255) NOT NULL
 ) ENGINE=InnoDB;
 
 -- RunAndLearnQuestion Table

--- a/src/main/java/com/gyu/engdu/domain/engdu/infra/InitialPromptGenerator.java
+++ b/src/main/java/com/gyu/engdu/domain/engdu/infra/InitialPromptGenerator.java
@@ -31,18 +31,20 @@ public class InitialPromptGenerator implements PromptGenerator {
         return """
           ### 글 구조 요구사항
 
-          1. 기사(article)를 작성해라.
-              - 정보 전달 글(기사)을 1개 만들어라.
-              - 주제는 입력된 `topic`을 중심으로 하되,
-                **주제를 단순 정의하거나 전반적 설명을 하는 것이 아니라 현실 세계의 실제 사례를 선택해 다뤄라.**
-                예시: topic이 `game`이라면 "How Video Games Inspire Problem-Solving Skills",
-                "The Chemistry Behind Choclate's Smooth Texture"처럼 구체적 사례를 서술해라.
-                **이 예시는 본문의 방향을 보여줄 뿐이며, 내용을 그대로 출력하지 마라. 출력할 사례는 당신이 다채롭게 생각해야한다.**
-              - 난이도(level)에 맞는 어휘와 문장을 사용해라.
-              - 본문은 영어 word count로 150words로 작성해라 (±10%).
-              - 본문의 내용 마지막은 문장 형태로 끝이 나되 다음 본문과 스토리를 이어 나갈 수 있게 해라.
-              - 사용자가 독해하기 쉽게 문장을 청크 단위로 나눠야한다. 문장 하나가 청크가 되는 것이 아닌 문장을 이루고있는 단어들을 나누어 청크로 만드는 것에 주의해라. 예를들어, 'Social media platformsemerged as powerful toolsfor connecting individualsacross geographical boundaries.' 문장이 있을 때 'Social media platform', 'emerged as powerful tools', 'for connecting individuals', 'across geographical boundaries.' 이렇게 4개의 청크로 나눌 수 있다.
-              - 본문의 해석본도 적는다. 해석본은 한국어로 청크 단위로 작성해야한다. 말투는 서술형 평서문으로 작성해라.
+          1. 기사(article)를 작성한다.
+              - 영어 독해 학습을 위한 정보 전달형 글을 1개 작성한다.
+              - topic을 중심으로 내용을 작성한다.
+                - topic이 일반적인 개념이라면, 하나의 구체적인 사례·상황·현상·기술 적용 사례 등을 중심으로 내용을 전개한다.
+                - topic이 이미 구체적인 질문이나 사례라면, topic 자체를 중심으로 내용을 전개한다.
+              - 백과사전식 정의나 개념 나열이 아니라, 하나의 중심 흐름을 따라 자연스럽게 내용을 전개한다.
+              - level에 맞는 어휘와 문장을 사용한다.
+              - 본문은 영어 기준 145~155 단어로 작성한다.
+              - 마지막 문장은 다음 이야기를 자연스럽게 이어갈 수 있는 형태로 마무리한다.
+              - 본문은 문장 단위가 아닌 청크(chunk) 단위로 분리한다.
+                - 청크는 의미 단위로 분리한다.
+                - 하나의 문장은 일반적으로 2~5개의 청크로 나눈다.
+                - 명사구, 구동사, 전치사구, 관용 표현은 가능한 한 분리하지 않는다.
+              - 모든 청크는 영어와 이에 대응하는 한국어 번역을 함께 작성하며, 번역은 서술형 평서문으로 작성한다.
 
           2. 제목(title)을 작성해라.
               - 본문의 내용에 알맞은 제목을 영어로 작성해라.
@@ -64,7 +66,7 @@ public class InitialPromptGenerator implements PromptGenerator {
                 "article": {
                     "chunks": [
                       ["영어 청크1", "한국어 청크1"],
-                      ["영어 청크2", "한국어 청크2"],
+                      ["영어 청크2", "한국어 청크2"]
                     ]
                 },
                 "questions": [

--- a/src/main/java/com/gyu/engdu/domain/gamification/application/listener/RunAndLearnUserDeletionListener.java
+++ b/src/main/java/com/gyu/engdu/domain/gamification/application/listener/RunAndLearnUserDeletionListener.java
@@ -1,13 +1,15 @@
-package com.gyu.engdu.domain.gamification.application;
+package com.gyu.engdu.domain.gamification.application.listener;
 
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
 import com.gyu.engdu.domain.user.domain.event.UserDeletedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class RunAndLearnUserDeletionListener {
 

--- a/src/main/java/com/gyu/engdu/domain/user/application/CreateUserService.java
+++ b/src/main/java/com/gyu/engdu/domain/user/application/CreateUserService.java
@@ -3,7 +3,9 @@ package com.gyu.engdu.domain.user.application;
 import com.gyu.engdu.domain.user.domain.Role;
 import com.gyu.engdu.domain.user.domain.User;
 import com.gyu.engdu.domain.user.domain.UserRepository;
+import com.gyu.engdu.domain.user.domain.event.UserRegisteredEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,10 +16,15 @@ public class CreateUserService {
 
   private final UserRepository userRepository;
   private final NameUserService nameUserService;
+  private final ApplicationEventPublisher eventPublisher;
+
   public User create(String sub, String email) {
     String name= nameUserService.getRandomName();
     User user = User.of(email, Role.ROLE_USER, sub, name);
     userRepository.save(user);
+
+    eventPublisher.publishEvent(new UserRegisteredEvent(user.getId(), user.getName()));
+
     return user;
   }
 }

--- a/src/main/java/com/gyu/engdu/domain/user/application/listener/UserRegisteredEventListener.java
+++ b/src/main/java/com/gyu/engdu/domain/user/application/listener/UserRegisteredEventListener.java
@@ -1,0 +1,25 @@
+package com.gyu.engdu.domain.user.application.listener;
+
+import com.gyu.engdu.domain.user.domain.event.UserRegisteredEvent;
+import com.gyu.engdu.global.infra.discord.DiscordWebhookSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRegisteredEventListener {
+
+    private final DiscordWebhookSender discordWebhookSender;
+
+    @Async("notifyWebhookTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserRegisteredEvent(UserRegisteredEvent event) {
+        log.info("새로운 사용자 가입 이벤트 수신: userId={}, nickname={}", event.userId(), event.nickname());
+        discordWebhookSender.sendUserRegisteredNotification(event.userId(), event.nickname());
+    }
+}

--- a/src/main/java/com/gyu/engdu/domain/user/domain/event/UserRegisteredEvent.java
+++ b/src/main/java/com/gyu/engdu/domain/user/domain/event/UserRegisteredEvent.java
@@ -1,0 +1,4 @@
+package com.gyu.engdu.domain.user.domain.event;
+
+public record UserRegisteredEvent(Long userId, String nickname) {
+}

--- a/src/main/java/com/gyu/engdu/global/config/AsyncConfig.java
+++ b/src/main/java/com/gyu/engdu/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.gyu.engdu.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "notifyWebhookTaskExecutor")
+    public Executor notifyWebhookTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("NotifyWebhook-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/gyu/engdu/global/infra/discord/DiscordWebhookSender.java
+++ b/src/main/java/com/gyu/engdu/global/infra/discord/DiscordWebhookSender.java
@@ -1,0 +1,48 @@
+package com.gyu.engdu.global.infra.discord;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+public class DiscordWebhookSender {
+
+    private final RestClient restClient;
+    private final String webhookUrl;
+
+    public DiscordWebhookSender(
+            @Value("${discord.webhook.signup.url:}") String webhookUrl
+    ) {
+        this.restClient = RestClient.create();
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void sendUserRegisteredNotification(Long userId, String nickname) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.warn("디스코드 웹훅 URL이 설정되지 않았습니다. 알림 전송을 건너뜁니다. userId={}", userId);
+            return;
+        }
+
+        try {
+            String message = String.format("🎉 **신규 회원 가입 알림** 🎉 회원 ID: `%d` - 닉네임: `%s`", userId,
+                    nickname);
+            Map<String, String> payload = Map.of("content", message);
+
+            restClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(payload)
+                    .retrieve()
+                    .toBodilessEntity();
+
+            log.info("디스코드 웹훅 알림을 성공적으로 전송했습니다. userId={}", userId);
+        } catch (RestClientException e) {
+            log.error("디스코드 웹훅 API 통신에 실패했습니다. userId={}, message={}", userId, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,3 +78,8 @@ oauth:
     login-uri: https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=${oauth.google.redirect-uri}&client_id=${oauth.google.client-id}
     local-redirect-uri: https://localhost:5173/oauth/callback/google
     local-login-uri: https://accounts.google.com/o/oauth2/auth?scope=https://www.googleapis.com/auth/userinfo.email+https://www.googleapis.com/auth/userinfo.profile&response_type=code&access_type=offline&redirect_uri=${oauth.google.local-redirect-uri}&client_id=${oauth.google.client-id}
+
+discord:
+  webhook:
+    signup:
+      url: ${DISCORD_SIGNUP_WEBHOOK_URL:}

--- a/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionListenerTest.java
+++ b/src/test/java/com/gyu/engdu/domain/gamification/application/RunAndLearnUserDeletionListenerTest.java
@@ -2,6 +2,7 @@ package com.gyu.engdu.domain.gamification.application;
 
 import static org.mockito.Mockito.verify;
 
+import com.gyu.engdu.domain.gamification.application.listener.RunAndLearnUserDeletionListener;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnRankingRepository;
 import com.gyu.engdu.domain.gamification.domain.RunAndLearnSessionRepository;
 import com.gyu.engdu.domain.user.domain.event.UserDeletedEvent;


### PR DESCRIPTION
## 연관된 이슈
- closed #161

## 작업 내용

### 개요
- 신규 회원 가입 완료 시 디스코드 웹훅으로 회원 정보를 비동기 전송합니다.
- 외부 API 통신 실패가 핵심 비즈니스 로직(회원가입) 트랜잭션에 영향을 주지 않도록 이벤트 기반 아키텍처를 도입했습니다.
- 기존 이벤트 리스너를 일관된 패키지 규칙에 맞추어 이동했습니다.

### 변경 사항
- **[웹훅 전송 클라이언트] (`DiscordWebhookSender.java`)**
  - `RestClient`를 이용하여 디스코드 웹훅 API 호출
  - 웹훅 실패 시 `RestClientException`을 잡아서 로깅만 남겨 메인 스레드에 예외를 전파하지 않습니다.
- **[가입 이벤트 비동기 리스너] (`UserRegisteredEventListener.java`, `AsyncConfig.java`)**
  - `@TransactionalEventListener(AFTER_COMMIT)`과 커스텀 `notifyWebhookTaskExecutor` 스레드 풀 기반 `@Async`를 통해 안전하게 비동기 처리
- **[유저 생성 도메인] (`CreateUserService.java`, `UserRegisteredEvent.java`)**
  - 유저 DB 저장 후 `ApplicationEventPublisher`를 통해 가입 이벤트를 발행합니다.
- **[기존 탈퇴 리스너 리팩터링] (`RunAndLearnUserDeletionListener.java`)**
  - `gamification/application/listener` 패키지로 클래스 이동

## 주요 고민 및 해결 과정
- **문제점**: 웹훅 API 장애 시 사용자 회원가입이 실패하는 결합도 문제
- **해결 과정**: 스프링 이벤트 모델과 `@Async` 비동기 스레드를 활용하여 관심사를 분리하고 의존성을 해소했습니다.