### PR TITLE
[CHORE] 개발 서버(dev) CD 파이프라인 AWS EC2 배포로 전환

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -45,15 +45,15 @@ jobs:
           docker push $IMAGE_NAME:$TAG
           docker push $IMAGE_NAME:latest
 
-      - name: NCP에 배포
+      - name: EC2에 배포
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.NCP_HOST }}
-          username: ${{ secrets.NCP_USER }}
-          password: ${{ secrets.NCP_PASSWORD }}
+          host: ${{ secrets.EC2_HOST_STAGING }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY_STAGING }}
           script: |
             set -e
-            cd /monitoring/engdu-dev
+            cd /home/${{ secrets.EC2_USER }}/engdu
 
             # (옵션) 레지스트리 로그인 필요 시
             sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## 연관된 이슈
- closed #166

## 작업 내용

### 개요
- 개발 서버 CD 파이프라인을 기존 NCP에서 AWS EC2로 전환.

### 변경 사항
- **[CD 파이프라인 수정] (`dev-cd.yml`)**
  - ssh 배포 타겟을 EC2로 변경.
  - prod 환경용 시크릿과 충돌을 피하기 위해, 개발 서버의 배포와 관련된 EC2 환경 변수 끝에 `_STAGING` 접미사를 추가.